### PR TITLE
fix(insights): make the alert_groups_total variable single-valued

### DIFF
--- a/grafana-plugin/src/dashboards/oncall_metrics_dashboard.json
+++ b/grafana-plugin/src/dashboards/oncall_metrics_dashboard.json
@@ -1279,8 +1279,8 @@
       {
         "current": {
           "selected": true,
-          "text": ["oncall_alert_groups_total", "grafanacloud_oncall_instance_alert_groups_total"],
-          "value": ["oncall_alert_groups_total", "grafanacloud_oncall_instance_alert_groups_total"]
+          "text": "oncall_alert_groups_total",
+          "value": "oncall_alert_groups_total"
         },
         "datasource": {
           "type": "prometheus",
@@ -1290,7 +1290,7 @@
         "hide": 2,
         "includeAll": false,
         "label": "alert_groups_total",
-        "multi": true,
+        "multi": false,
         "name": "alert_groups_total",
         "options": [],
         "query": {
@@ -1299,7 +1299,7 @@
         },
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
+        "skipUrlSync": true,
         "sort": 0,
         "type": "query"
       },

--- a/grafana-plugin/src/pages/insights/variables.ts
+++ b/grafana-plugin/src/pages/insights/variables.ts
@@ -84,8 +84,14 @@ const getVariables = ({ isOpenSource, datasource, stack }: InsightsConfig) => ({
       query: 'metrics(alert_groups_total)',
       refId: 'PrometheusVariableQueryEditor-VariableQuery',
     },
-    text: ['oncall_alert_groups_total', 'grafanacloud_oncall_instance_alert_groups_total'],
-    value: ['oncall_alert_groups_total', 'grafanacloud_oncall_instance_alert_groups_total'],
+    // panels interpolate this straight into PromQL as the metric name, so it has to resolve to a
+    // single value; the query above repopulates it for the environment in play. A hidden variable
+    // has no business round-tripping through the URL either — a restored multi-value seed makes
+    // every Insights panel query invalid.
+    isMulti: false,
+    skipUrlSync: true,
+    text: 'oncall_alert_groups_total',
+    value: 'oncall_alert_groups_total',
     definition: 'metrics(alert_groups_total)',
     hide: 2,
   }),


### PR DESCRIPTION
Moves a production workaround from `appwrite-labs/monitoring` into source.

## The bug

Insights panels interpolate the variable straight into PromQL **as the metric name**:

```ts
expr: `round(delta(sum by (integration)($alert_groups_total{slug=~"..."})[$__interval:])) >= 0`
```

But `alert_groups_total` was seeded with a two-element value and left URL-synced despite being hidden (`hide: 2`):

```ts
text: ['oncall_alert_groups_total', 'grafanacloud_oncall_instance_alert_groups_total'],
value: ['oncall_alert_groups_total', 'grafanacloud_oncall_instance_alert_groups_total'],
```

A multi-value variable interpolates as a regex alternation, which is not valid where a metric name belongs. It normally goes unnoticed because the variable's own query (`metrics(alert_groups_total)`) refreshes it down to the one metric that exists — but when the seeded pair is restored, which is exactly what URL sync causes, **every panel on the page emits a broken query**. Grafana 13 hits this.

## The fix

`isMulti: false`, `skipUrlSync: true`, single seed. The query still repopulates the correct metric name for whichever environment is in play, so nothing is lost by dropping the `grafanacloud_` name from the seed — and a hidden variable has no business round-tripping through the URL in the first place.

The other four hidden variables never hardcoded seeds, which is why this was the only one affected. The standalone `oncall_metrics_dashboard.json` carried the same latent bug (`multi: true`, `skipUrlSync: false`, paired `current`), fixed identically.

## Why now

`appwrite-labs/monitoring` works around this in production: `telemetry/grafana/patch-oncall-insights.sh` **sed-patches the minified `module.js`** of the archived 1.16.11 plugin at container start, then **deletes `MANIFEST.txt`** because editing a signed bundle invalidates its signature, which is why compose needs `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app`.

This makes that patch redundant. Verified by building and grepping `dist/module.js`:

| string | before | after |
|---|---|---|
| the patch's search needle | 1 | **0** |
| the patch's replacement | 0 | **1** |

So the shipped bundle is byte-equivalent to what the workaround produces, and the script would take its "already patched" branch. Once monitoring builds the plugin from this fork it can delete the script, the MANIFEST removal, and — assuming the build is signed or the fork's plugin is allow-listed for other reasons — revisit the unsigned-plugin env var.

## Verified

`tsc` clean, ESLint 0 errors, production build succeeds, unit tests pass. No e2e coverage: the Insights suite is `test.describe.skip`'d upstream as flaky, so the bundle-content check above is the substantive verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)