### PR TITLE
ci: attach a plugin archive to each release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,3 +73,64 @@ jobs:
             --tag ${{ env.IMAGE }}:latest \
             ${{ env.IMAGE }}:${{ github.ref_name }}-amd64 \
             ${{ env.IMAGE }}:${{ github.ref_name }}-arm64
+
+  plugin:
+    name: Package Grafana plugin
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v4
+
+      - name: Install frontend dependencies
+        uses: ./.github/actions/install-frontend-dependencies
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: grafana-plugin/go.mod
+
+      - name: Install Mage
+        run: go install github.com/magefile/mage@v1.15.0
+
+      - name: Build and package plugin
+        working-directory: grafana-plugin
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # a version without the leading "v" is what tells the plugin it is an OSS build, and it
+          # has to be stamped before either build: webpack substitutes it into plugin.json and the
+          # backend bakes it into the binary
+          version="${TAG#v}"
+          jq --arg v "$version" '.version=$v' package.json > package.tmp && mv package.tmp package.json
+
+          pnpm build
+          mage -v build:linux build:linuxARM64
+
+          # the plugin declares a backend, so a frontend-only archive would not load
+          test -f dist/gpx_grafana_oncall_app_linux_amd64
+          test -f dist/gpx_grafana_oncall_app_linux_arm64
+
+          # grafana expects the archive's directory to be named after the plugin id. The build is
+          # unsigned — we have no grafana.com access policy to sign under — so installs need the
+          # plugin allow-listed via GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS.
+          mv dist grafana-oncall-app
+          zip -qr "grafana-oncall-app-${version}.zip" ./grafana-oncall-app
+          sha256sum "grafana-oncall-app-${version}.zip" > "grafana-oncall-app-${version}.zip.sha256"
+
+      - name: Attach plugin to release
+        working-directory: grafana-plugin
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG#v}"
+          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --generate-notes --title "$TAG"
+          gh release upload "$TAG" \
+            "grafana-oncall-app-${version}.zip" \
+            "grafana-oncall-app-${version}.zip.sha256" \
+            --clobber


### PR DESCRIPTION
Unblocks pointing `appwrite-labs/monitoring` at this fork's plugin.

## Why

`publish.yml` built only the engine image, and releases carry **0 assets**. So there is nowhere to get this fork's plugin build — a self-hosted stack has to `grafana cli plugins install grafana-oncall-app` from grafana.com, which serves Grafana's **archived 1.16.11** build. That build predates:

- the React 19 fixes from #11, which Grafana 13 needs (it ships React 19, and 1.16.11 still calls the removed `findDOMNode` via react-sortable-hoc, react-draggable and react-transition-group)
- the Insights variable fix from #17

## What this adds

A `plugin` job on every `v*` tag that builds and attaches `grafana-oncall-app-<version>.zip` (plus a `.sha256`) to the GitHub release.

Details that matter:

- **Version is stamped before building.** webpack substitutes it into `plugin.json` (which ships `%VERSION%`) and the Go backend bakes it into the binary via ldflags, so stamping afterwards would ship a mislabelled plugin. The leading `v` is dropped because that is what marks an OSS build.
- **Both linux backend binaries are included.** `plugin.json` declares `"backend": true` with `executable: gpx_grafana_oncall_app`, so a frontend-only archive would not load. Note the upstream packaging ran `mage buildAll || true` — tolerating a silently missing backend; this asserts both binaries exist instead.
- **The archive directory is named after the plugin id**, which is what Grafana expects to unpack.
- **It is unsigned.** Signing needs a grafana.com access policy token we do not have, so installing it requires `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app`. monitoring already sets exactly that (for its sed-patched build), so this is not a new requirement there.

## Verified locally

Ran the whole sequence against this tree, not just eyeballed it:

- `pnpm build` → `dist/plugin.json` correctly shows the stamped version (checked with 1.19.0)
- `mage build:linux build:linuxARM64` → both binaries produced (~25MB and ~24MB)
- zip → 73 files containing `plugin.json`, `module.js` and both `gpx_*` binaries
- workflow YAML parses; job declares `contents: write` for the release upload

## Note on v1.19.0

This job cannot run retroactively, so **v1.19.0 will have no plugin asset**. A patch release after this merges is the cleanest way to produce the first archive — and it doubles as the first real exercise of the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)