### PR TITLE
chore: point this repo's own manifests and docs at the fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,33 @@
 # Appwrite's fork of Grafana OnCall
 
-Grafana archived OnCall OSS on 2026-03-24. [Appwrite](https://appwrite.io) maintains this
-fork for its own use — we keep it working for our needs, but offer no support or
-roadmap commitments. Engine images are published to
-[`ghcr.io/appwrite/grafana-oncall`](https://github.com/appwrite/grafana-oncall/pkgs/container/grafana-oncall).
+Grafana archived [OnCall OSS](https://github.com/grafana/oncall) on 2026-03-24 at v1.16.11.
+[Appwrite](https://appwrite.io) maintains this fork for its own use.
+
+## What's different from upstream
+
+- **It runs on current Grafana.** Grafana 13 ships React 19, which removed `ReactDOM.findDOMNode`.
+  Upstream's plugin reaches it through three libraries, so escalation chains, notification policies
+  and the rotation modals crash on mount. Fixed by moving drag-and-drop to `@dnd-kit`, passing
+  `nodeRef` to `react-draggable`, and replacing `react-transition-group` with a CSS animation.
+- **Insights renders.** Its `alert_groups_total` variable was seeded multi-valued and URL-synced, so
+  a restored value interpolated a regex where PromQL wants a metric name, breaking every panel.
+- **End-to-end tests run against Grafana 12 and 13**, where upstream tested 10 and 11.
+- **~290 security patches.** Dependabot alerts went from 309 to 18.
+- **Django 5.2 LTS**, where upstream is on 4.2 — its extended support ended in April 2026.
+- **`fcm-django` from PyPI** rather than a tarball of a now-archived fork.
+- **Releases ship both halves**: multi-arch engine images to
+  [`ghcr.io/appwrite/grafana-oncall`](https://github.com/appwrite/grafana-oncall/pkgs/container/grafana-oncall)
+  and a plugin archive attached to each
+  [release](https://github.com/appwrite/grafana-oncall/releases). Upstream's catalog build is frozen
+  at 1.16.11.
+
+## What it does not offer
+
+- No support and no roadmap commitments. We keep it working for our needs.
+- The plugin is unsigned, since signing needs a grafana.com access policy, so it needs
+  `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-oncall-app`.
+- The helm chart is not published to a helm repository; install it from a checkout.
+- The mobile app relied on Grafana Cloud's push relay, which went away with the archival.
 
 ## Grafana OnCall
 
@@ -46,7 +70,7 @@ We prepared multiple environments:
 1. Download [`docker-compose.yml`](docker-compose.yml):
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/grafana/oncall/dev/docker-compose.yml -o docker-compose.yml
+   curl -fsSL https://raw.githubusercontent.com/appwrite/grafana-oncall/main/docker-compose.yml -o docker-compose.yml
    ```
 
 2. Set variables:
@@ -138,26 +162,22 @@ docker-compose pull engine
 docker-compose up -d
 ```
 
-After updating the engine, you'll also need to click the "Update" button on the [plugin version page](http://localhost:3000/plugins/grafana-oncall-app?page=version-history).
-See [Grafana docs](https://grafana.com/docs/grafana/latest/administration/plugin-management/#update-a-plugin) for more
-info on updating Grafana plugins.
+The plugin is not published to grafana.com, so it does not update through the plugin catalog. Point
+`GF_INSTALL_PLUGINS` at the archive from the [release](https://github.com/appwrite/grafana-oncall/releases)
+matching the engine tag and recreate the Grafana container.
 
 ## Join community
 
 [<img width="200px" src="docs/img/slack.png">](https://slack.grafana.com/)
 [<img width="200px" src="docs/img/GH_discussions.png">](https://community.grafana.com/)
 
-Have a question, comment or feedback? Don't be afraid to [open an issue](https://github.com/grafana/oncall/issues/new/choose)!
-
-## Stargazers over time
-
-[![Stargazers over time](https://starchart.cc/grafana/oncall.svg)](https://starchart.cc/grafana/oncall)
+Have a question, comment or feedback? Don't be afraid to [open an issue](https://github.com/appwrite/grafana-oncall/issues/new/choose)!
 
 ## Further Reading
 
-- _Automated migration from other on-call tools_ - [Migrator](https://github.com/grafana/oncall/tree/dev/tools/migrators)
+- _Automated migration from other on-call tools_ - [Migrator](https://github.com/appwrite/grafana-oncall/tree/main/tools/migrators)
 - _Documentation_ - [Grafana OnCall](https://grafana.com/docs/oncall/latest/)
 - _Overview Webinar_ - [YouTube](https://www.youtube.com/watch?v=7uSe1pulgs8)
-- _How To Add Integration_ - [How to Add Integration](https://github.com/grafana/oncall/tree/dev/engine/config_integrations/README.md)
+- _How To Add Integration_ - [How to Add Integration](https://github.com/appwrite/grafana-oncall/tree/main/engine/config_integrations/README.md)
 - _Blog Post_ - [Announcing Grafana OnCall, the easiest way to do on-call management](https://grafana.com/blog/2021/11/09/announcing-grafana-oncall/)
 - _Presentation_ - [Deep dive into the Grafana, Prometheus, and Alertmanager stack for alerting and on-call management](https://grafana.com/go/observabilitycon/2021/alerting/?pg=blog)

--- a/README.md
+++ b/README.md
@@ -152,19 +152,25 @@ Here are some API calls that can be made to help if you are having difficulty co
 
 ## Update version
 
-To update your Grafana OnCall hobby environment:
+The engine and plugin are released together and are not meant to be mixed across versions, so one
+variable moves both. Set it to the [release](https://github.com/appwrite/grafana-oncall/releases) you
+want in `.env`:
 
 ```shell
-# Update Docker image
-docker-compose pull engine
+echo "ONCALL_VERSION=1.19.1" >> .env
 
-# Re-deploy
+docker-compose pull
 docker-compose up -d
 ```
 
-The plugin is not published to grafana.com, so it does not update through the plugin catalog. Point
-`GF_INSTALL_PLUGINS` at the archive from the [release](https://github.com/appwrite/grafana-oncall/releases)
-matching the engine tag and recreate the Grafana container.
+The plugin is not in the grafana.com catalog, so it does not update through the plugin page. Grafana
+only installs a plugin that is not already present, so to move the plugin you also have to clear the
+old copy from its volume:
+
+```shell
+docker-compose exec grafana rm -rf /var/lib/grafana/plugins/grafana-oncall-app
+docker-compose restart grafana
+```
 
 ## Join community
 

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -8,8 +8,7 @@ x-oncall-build: &oncall-build-args
   target: ${ONCALL_IMAGE_TARGET:-dev}
   labels: *oncall-labels
   cache_from:
-    - grafana/oncall:latest
-    - grafana/oncall:dev
+    - ghcr.io/appwrite/grafana-oncall:latest
 
 x-oncall-volumes: &oncall-volumes
   - ./engine:/etc/app

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -22,7 +22,7 @@ x-environment: &oncall-environment
 
 services:
   engine:
-    image: grafana/oncall
+    image: ghcr.io/appwrite/grafana-oncall:latest
     restart: always
     ports:
       - "8080:8080"
@@ -39,7 +39,7 @@ services:
         condition: service_started
 
   celery:
-    image: grafana/oncall
+    image: ghcr.io/appwrite/grafana-oncall:latest
     restart: always
     command: sh -c "./celery_with_exporter.sh"
     environment: *oncall-environment
@@ -54,7 +54,7 @@ services:
         condition: service_started
 
   oncall_db_migration:
-    image: grafana/oncall
+    image: ghcr.io/appwrite/grafana-oncall:latest
     command: python manage.py migrate --noinput
     environment: *oncall-environment
     depends_on:
@@ -143,7 +143,9 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
-      GF_INSTALL_PLUGINS: grafana-oncall-app
+      # the catalog build is grafana's archived one, so install this fork's plugin archive
+      # yamllint disable-line rule:line-length
+      GF_INSTALL_PLUGINS: ${ONCALL_PLUGIN_URL:-https://github.com/appwrite/grafana-oncall/releases/download/v1.19.1/grafana-oncall-app-1.19.1.zip};grafana-oncall-app
       GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
     deploy:
       resources:

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -22,7 +22,7 @@ x-environment: &oncall-environment
 
 services:
   engine:
-    image: ghcr.io/appwrite/grafana-oncall:latest
+    image: ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION:-1.19.1}
     restart: always
     ports:
       - "8080:8080"
@@ -39,7 +39,7 @@ services:
         condition: service_started
 
   celery:
-    image: ghcr.io/appwrite/grafana-oncall:latest
+    image: ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION:-1.19.1}
     restart: always
     command: sh -c "./celery_with_exporter.sh"
     environment: *oncall-environment
@@ -54,7 +54,7 @@ services:
         condition: service_started
 
   oncall_db_migration:
-    image: ghcr.io/appwrite/grafana-oncall:latest
+    image: ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION:-1.19.1}
     command: python manage.py migrate --noinput
     environment: *oncall-environment
     depends_on:
@@ -143,9 +143,11 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
-      # the catalog build is grafana's archived one, so install this fork's plugin archive
+      # The catalog build is grafana's archived one, so install this fork's plugin archive.
+      # ONCALL_VERSION pins the engine too: the plugin and engine are released together
+      # and are not meant to be mixed across versions.
       # yamllint disable-line rule:line-length
-      GF_INSTALL_PLUGINS: ${ONCALL_PLUGIN_URL:-https://github.com/appwrite/grafana-oncall/releases/download/v1.19.1/grafana-oncall-app-1.19.1.zip};grafana-oncall-app
+      GF_INSTALL_PLUGINS: https://github.com/appwrite/grafana-oncall/releases/download/v${ONCALL_VERSION:-1.19.1}/grafana-oncall-app-${ONCALL_VERSION:-1.19.1}.zip;grafana-oncall-app
       GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
     deploy:
       resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ x-environment: &oncall-environment
 
 services:
   engine:
-    image: ghcr.io/appwrite/grafana-oncall:latest
+    image: ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION:-1.19.1}
     restart: always
     ports:
       - "8080:8080"
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
 
   celery:
-    image: ghcr.io/appwrite/grafana-oncall:latest
+    image: ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION:-1.19.1}
     restart: always
     command: sh -c "./celery_with_exporter.sh"
     environment: *oncall-environment
@@ -44,7 +44,7 @@ services:
         condition: service_healthy
 
   oncall_db_migration:
-    image: ghcr.io/appwrite/grafana-oncall:latest
+    image: ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION:-1.19.1}
     command: python manage.py migrate --noinput
     environment: *oncall-environment
     volumes:
@@ -93,9 +93,11 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
-      # the catalog build is grafana's archived one, so install this fork's plugin archive
+      # The catalog build is grafana's archived one, so install this fork's plugin archive.
+      # ONCALL_VERSION pins the engine too: the plugin and engine are released together
+      # and are not meant to be mixed across versions.
       # yamllint disable-line rule:line-length
-      GF_INSTALL_PLUGINS: ${ONCALL_PLUGIN_URL:-https://github.com/appwrite/grafana-oncall/releases/download/v1.19.1/grafana-oncall-app-1.19.1.zip};grafana-oncall-app
+      GF_INSTALL_PLUGINS: https://github.com/appwrite/grafana-oncall/releases/download/v${ONCALL_VERSION:-1.19.1}/grafana-oncall-app-${ONCALL_VERSION:-1.19.1}.zip;grafana-oncall-app
       GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
     volumes:
       - grafana_data:/var/lib/grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ x-environment: &oncall-environment
 
 services:
   engine:
-    image: grafana/oncall
+    image: ghcr.io/appwrite/grafana-oncall:latest
     restart: always
     ports:
       - "8080:8080"
@@ -31,7 +31,7 @@ services:
         condition: service_healthy
 
   celery:
-    image: grafana/oncall
+    image: ghcr.io/appwrite/grafana-oncall:latest
     restart: always
     command: sh -c "./celery_with_exporter.sh"
     environment: *oncall-environment
@@ -44,7 +44,7 @@ services:
         condition: service_healthy
 
   oncall_db_migration:
-    image: grafana/oncall
+    image: ghcr.io/appwrite/grafana-oncall:latest
     command: python manage.py migrate --noinput
     environment: *oncall-environment
     volumes:
@@ -93,7 +93,9 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
-      GF_INSTALL_PLUGINS: grafana-oncall-app
+      # the catalog build is grafana's archived one, so install this fork's plugin archive
+      # yamllint disable-line rule:line-length
+      GF_INSTALL_PLUGINS: ${ONCALL_PLUGIN_URL:-https://github.com/appwrite/grafana-oncall/releases/download/v1.19.1/grafana-oncall-app-1.19.1.zip};grafana-oncall-app
       GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
     volumes:
       - grafana_data:/var/lib/grafana

--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oncall
 description: Developer-friendly incident response with brilliant Slack integration
 type: application
-version: 1.15.6
-appVersion: v1.15.6
+version: 1.19.1
+appVersion: v1.19.1
 dependencies:
   - name: cert-manager
     version: v1.8.0

--- a/helm/oncall/README.md
+++ b/helm/oncall/README.md
@@ -5,7 +5,7 @@ It will deploy Grafana OnCall engine and celery workers, along with RabbitMQ clu
 It will also deploy cert manager and nginx ingress controller, as Grafana OnCall backend might need to be externally available
 to receive alerts from other monitoring systems. Grafana OnCall engine acts as a backend and can be connected to the
 Grafana frontend plugin named Grafana OnCall.
-Architecture diagram can be found [here](https://raw.githubusercontent.com/grafana/oncall/dev/docs/img/architecture_diagram.png)
+Architecture diagram can be found [here](https://raw.githubusercontent.com/appwrite/grafana-oncall/main/docs/img/architecture_diagram.png)
 
 ## Production usage
 
@@ -23,12 +23,13 @@ Here are the instructions on how to set up your own [ingress](#set-up-external-a
 
 ## Install
 
-### Prepare the repo
+### Prepare the chart
+
+This chart is not published to a helm repository, so install it from a checkout:
 
 ```bash
-# Add the repository
-helm repo add grafana https://grafana.github.io/helm-charts
-helm repo update
+git clone https://github.com/appwrite/grafana-oncall.git
+cd grafana-oncall
 ```
 
 ### Installing the helm chart
@@ -40,7 +41,7 @@ helm install \
     --set base_url=example.com \
     --set grafana."grafana\.ini".server.domain=example.com \
     release-oncall \
-    grafana/oncall
+    ./helm/oncall
 ```
 
 Follow the `helm install` output to finish setting up Grafana OnCall backend and Grafana OnCall frontend plugin e.g.
@@ -83,7 +84,7 @@ helm upgrade \
     --set base_url=example.com \
     --set grafana."grafana\.ini".server.domain=example.com \
     release-oncall \
-    grafana/oncall
+    ./helm/oncall
 ```
 
 ### Passwords and external secrets
@@ -382,9 +383,8 @@ externalRedis:
 ## Update
 
 ```bash
-# Add & upgrade the repository
-helm repo add grafana https://grafana.github.io/helm-charts
-helm repo update
+# Pull the latest chart
+git pull
 
 # Re-deploy
 helm upgrade \
@@ -393,7 +393,7 @@ helm upgrade \
     --set base_url=example.com \
     --set grafana."grafana\.ini".server.domain=example.com \
     release-oncall \
-    grafana/oncall
+    ./helm/oncall
 ```
 
 After re-deploying, please also update the Grafana OnCall plugin on the plugin version page.

--- a/helm/oncall/README.md
+++ b/helm/oncall/README.md
@@ -396,10 +396,10 @@ helm upgrade \
     ./helm/oncall
 ```
 
-The plugin is not in the grafana.com catalog, so it does not update through the plugin page. It is
-installed from the archive in `grafana.plugins`, which has to be moved to the same version as
-`image.tag`/`appVersion` — the engine and plugin are released together and are not meant to be mixed
-across versions.
+The plugin is not in the grafana.com catalog, so it does not update through the plugin page. The
+bundled Grafana installs it from this fork's release archive, and the chart derives that version from
+`image.tag` (falling back to the chart's `appVersion`) — so bumping the engine moves the plugin with
+it, and the two cannot end up on different versions.
 
 Grafana only installs a plugin that is not already present, so with `grafana.persistence` enabled the
 old copy has to be cleared before it will reinstall:

--- a/helm/oncall/README.md
+++ b/helm/oncall/README.md
@@ -396,9 +396,18 @@ helm upgrade \
     ./helm/oncall
 ```
 
-After re-deploying, please also update the Grafana OnCall plugin on the plugin version page.
-See [Grafana docs](https://grafana.com/docs/grafana/latest/administration/plugin-management/#update-a-plugin) for
-more info on updating Grafana plugins.
+The plugin is not in the grafana.com catalog, so it does not update through the plugin page. It is
+installed from the archive in `grafana.plugins`, which has to be moved to the same version as
+`image.tag`/`appVersion` — the engine and plugin are released together and are not meant to be mixed
+across versions.
+
+Grafana only installs a plugin that is not already present, so with `grafana.persistence` enabled the
+old copy has to be cleared before it will reinstall:
+
+```bash
+kubectl exec deploy/release-oncall-grafana -- rm -rf /var/lib/grafana/plugins/grafana-oncall-app
+kubectl rollout restart deploy/release-oncall-grafana
+```
 
 ## Uninstall
 

--- a/helm/oncall/templates/grafana-plugin-env.yaml
+++ b/helm/oncall/templates/grafana-plugin-env.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.grafana.enabled }}
+{{/*
+  The plugin is not in the grafana.com catalog, so the bundled Grafana installs it from this fork's
+  release archive. The version is taken from the same expression as the engine image, so overriding
+  image.tag moves both halves: they are released together and are not meant to be mixed.
+
+  This is a ConfigMap because subchart values cannot be templated — grafana.envValueFrom points at
+  it, and the grafana chart runs tpl over that block so it can resolve the release-scoped name.
+*/}}
+{{- $version := .Values.image.tag | default .Chart.AppVersion }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-oncall-plugin
+  labels:
+    app: {{ include "oncall.name" . }}
+data:
+  GF_INSTALL_PLUGINS: https://github.com/appwrite/grafana-oncall/releases/download/{{ $version }}/grafana-oncall-app-{{ trimPrefix "v" $version }}.zip;grafana-oncall-app
+{{- end }}

--- a/helm/oncall/tests/__snapshot__/integrations_deployment_test.yaml.snap
+++ b/helm/oncall/tests/__snapshot__/integrations_deployment_test.yaml.snap
@@ -102,7 +102,7 @@ detached_integrations.enabled=true -> should create integrations deployment:
           value: ""
         - name: ROOT_URLCONF
           value: engine.integrations_urls
-      image: grafana/oncall:v1.3.39
+      image: ghcr.io/appwrite/grafana-oncall:v1.3.39
       imagePullPolicy: Always
       livenessProbe:
         httpGet:

--- a/helm/oncall/tests/__snapshot__/telegram_polling_deployment_test.yaml.snap
+++ b/helm/oncall/tests/__snapshot__/telegram_polling_deployment_test.yaml.snap
@@ -84,7 +84,7 @@ telegramPolling.enabled=true -> should create telegram polling deployment:
           value: amqp
         - name: RABBITMQ_VHOST
           value: ""
-      image: grafana/oncall:v1.2.36
+      image: ghcr.io/appwrite/grafana-oncall:v1.2.36
       imagePullPolicy: Always
       name: telegram-polling
       securityContext: {}

--- a/helm/oncall/tests/__snapshot__/wait_for_db_test.yaml.snap
+++ b/helm/oncall/tests/__snapshot__/wait_for_db_test.yaml.snap
@@ -76,7 +76,7 @@ database.type=mysql -> should create initContainer for MySQL database (default):
           value: amqp
         - name: RABBITMQ_VHOST
           value: ""
-      image: grafana/oncall:v1.2.36
+      image: ghcr.io/appwrite/grafana-oncall:v1.2.36
       imagePullPolicy: Always
       name: wait-for-db
       resources:
@@ -164,7 +164,7 @@ database.type=mysql -> should create initContainer for MySQL database (default):
           value: amqp
         - name: RABBITMQ_VHOST
           value: ""
-      image: grafana/oncall:v1.2.36
+      image: ghcr.io/appwrite/grafana-oncall:v1.2.36
       imagePullPolicy: Always
       name: wait-for-db
       resources:
@@ -252,7 +252,7 @@ database.type=mysql -> should create initContainer for MySQL database (default):
           value: amqp
         - name: RABBITMQ_VHOST
           value: ""
-      image: grafana/oncall:v1.2.36
+      image: ghcr.io/appwrite/grafana-oncall:v1.2.36
       imagePullPolicy: Always
       name: wait-for-db
       resources:
@@ -343,7 +343,7 @@ database.type=postgresql -> should create initContainer for PostgreSQL database:
           value: amqp
         - name: RABBITMQ_VHOST
           value: ""
-      image: grafana/oncall:v1.2.36
+      image: ghcr.io/appwrite/grafana-oncall:v1.2.36
       imagePullPolicy: Always
       name: wait-for-db
       resources:
@@ -433,7 +433,7 @@ database.type=postgresql -> should create initContainer for PostgreSQL database:
           value: amqp
         - name: RABBITMQ_VHOST
           value: ""
-      image: grafana/oncall:v1.2.36
+      image: ghcr.io/appwrite/grafana-oncall:v1.2.36
       imagePullPolicy: Always
       name: wait-for-db
       resources:
@@ -523,7 +523,7 @@ database.type=postgresql -> should create initContainer for PostgreSQL database:
           value: amqp
         - name: RABBITMQ_VHOST
           value: ""
-      image: grafana/oncall:v1.2.36
+      image: ghcr.io/appwrite/grafana-oncall:v1.2.36
       imagePullPolicy: Always
       name: wait-for-db
       resources:

--- a/helm/oncall/tests/image_deployments_test.yaml
+++ b/helm/oncall/tests/image_deployments_test.yaml
@@ -15,7 +15,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: grafana/oncall:1.2.36
+          value: ghcr.io/appwrite/grafana-oncall:1.2.36
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -642,13 +642,18 @@ grafana:
       accessControlOnCall: false
   env:
     GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
+    # this fork's plugin carries no grafana.com signature
+    GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
   persistence:
     enabled: true
   # Disable psp as PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
   rbac:
     pspEnabled: false
   plugins:
-    - grafana-oncall-app
+    # Not the catalog build, which is grafana's archived one. Keep this version in step with
+    # image.tag/appVersion above: the plugin and engine are released together.
+    # yamllint disable-line rule:line-length
+    - https://github.com/appwrite/grafana-oncall/releases/download/v1.19.1/grafana-oncall-app-1.19.1.zip;grafana-oncall-app
   extraVolumes:
     - name: provisioning
       configMap:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -649,11 +649,14 @@ grafana:
   # Disable psp as PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
   rbac:
     pspEnabled: false
-  plugins:
-    # Not the catalog build, which is grafana's archived one. Keep this version in step with
-    # image.tag/appVersion above: the plugin and engine are released together.
-    # yamllint disable-line rule:line-length
-    - https://github.com/appwrite/grafana-oncall/releases/download/v1.19.1/grafana-oncall-app-1.19.1.zip;grafana-oncall-app
+  # The plugin archive comes from the ConfigMap this chart renders, which derives the version from
+  # image.tag/appVersion — so the engine and plugin cannot end up on different versions. Setting
+  # grafana.plugins here instead would install the catalog build, which is grafana's archived one.
+  envValueFrom:
+    GF_INSTALL_PLUGINS:
+      configMapKeyRef:
+        name: '{{ .Release.Name }}-oncall-plugin'
+        key: GF_INSTALL_PLUGINS
   extraVolumes:
     - name: provisioning
       configMap:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -15,7 +15,7 @@ imagePullSecrets: []
 
 image:
   # Grafana OnCall docker image repository
-  repository: grafana/oncall
+  repository: ghcr.io/appwrite/grafana-oncall
   tag:
   pullPolicy: Always
 


### PR DESCRIPTION
Closes #10.

Following our own README produced Grafana's **archived** engine paired with a plugin that crashes on Grafana 13 — the compose stacks and helm chart still pulled `grafana/oncall`, and the quickstart installed `grafana-oncall-app` from the grafana.com catalog.

## Engine and plugin move together

The engine and plugin are released together and are not meant to be mixed across versions, so each compose stack pins both from **one** variable:

```yaml
image: ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION:-1.19.1}
GF_INSTALL_PLUGINS: https://…/download/v${ONCALL_VERSION:-1.19.1}/grafana-oncall-app-${ONCALL_VERSION:-1.19.1}.zip;grafana-oncall-app
```

Verified by rendering the stack, with the default and with an override:

| `ONCALL_VERSION` | engine | plugin archive |
|---|---|---|
| unset | `…:v1.19.1` | `…/v1.19.1/grafana-oncall-app-1.19.1.zip` |
| `1.20.0` | `…:v1.20.0` | `…/v1.20.0/grafana-oncall-app-1.20.0.zip` |

An earlier revision of this PR had `:latest` for the engine against a fixed plugin archive, which would have drifted apart on the next release.

## Images

| file | before | after |
|---|---|---|
| `docker-compose.yml` (×3) | `grafana/oncall` | `ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION}` |
| `docker-compose-mysql-rabbitmq.yml` (×3) | `grafana/oncall` | same |
| `docker-compose-developer.yml` | `cache_from` grafana's `:latest` and `:dev` | our `:latest` (we never publish `:dev`) |
| `helm/oncall/values.yaml` | `image.repository: grafana/oncall` | `ghcr.io/appwrite/grafana-oncall` |

**GHCR visibility needed no change** — the other half of #10. The package is anonymously pullable (verified with an anonymous registry token), so compose works without credentials.

## The chart was broken twice over

- **`appVersion` was `v1.15.6`**, and `_helpers.tpl` falls back to it for the image tag — so a default install asked our registry for a tag that does not exist. Chart `version`/`appVersion` now track the release.
- **`grafana.plugins` still listed the catalog id**, installing Grafana's archived build alongside our engine. It now installs this fork's release archive, and the grafana subchart sets `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS`, without which an unsigned plugin is rejected.

The plugin version is **derived, not restated**. Subchart values cannot be templated, but the grafana chart runs `tpl` over `envValueFrom`, so it can reference a ConfigMap this chart renders — and that ConfigMap builds `GF_INSTALL_PLUGINS` from the same expression the engine image uses (`image.tag | default .Chart.AppVersion`). So overriding the engine moves the plugin with it:

```console
$ helm template rel . --set image.tag=v1.20.0
    image: ghcr.io/appwrite/grafana-oncall:v1.20.0
    GF_INSTALL_PLUGINS: …/download/v1.20.0/grafana-oncall-app-1.20.0.zip;grafana-oncall-app
```

(The archive name drops the leading `v` while the tag keeps it, hence a `trimPrefix`.) An earlier revision of this PR hardcoded the URL in `grafana.plugins`, which would have left the plugin behind whenever `image.tag` was overridden.

Repointing `image.repository` also required updating the assertion in `image_deployments_test.yaml` and **three rendered snapshots**; that diff is exclusively the 8 image lines. Suite is green: `34 suites, 111 tests, 20 snapshots`.

`helm/oncall/README.md` told users to `helm repo add grafana …` then install `grafana/oncall`. That is a chart reference, not an image, and it is stale for a different reason: **this fork does not publish a helm chart** (the workflow that did was Grafana-internal, removed in #6). It now installs from a checkout.

## Update instructions

Both READMEs told users to update the plugin from Grafana's plugin version page. That cannot work for a plugin outside the catalog — it would leave the stale catalog build against an updated engine. They now move `ONCALL_VERSION` (compose) or the `grafana.plugins` archive (helm), and both note the operational catch: **Grafana only installs a plugin that is not already present**, so with a persistent volume the old copy has to be cleared before it will reinstall.

## README

Rewrote the header as an explicit **What's different from upstream** list — Grafana 13/React 19 support, Insights rendering, the e2e matrix, ~290 security patches, Django 5.2, fcm-django from PyPI, releases shipping both halves — followed by **What it does not offer**, stating the unsigned plugin, the unpublished chart, the dead mobile push relay and the absence of support. Previously the reasons to prefer this fork were implied at best.

Also fixed links into the archived repo (open-an-issue, Migrator, integrations guide, helm architecture diagram) and **removed the stargazers chart**, which renders a GitHub API error instead of a graph.

## Verified

`docker compose config` renders both stacks with matching versions; helm suite passes with updated snapshots; pre-commit (yamllint, markdownlint) clean. The long plugin URLs carry `yamllint disable-line`, matching the convention already used in this repo, since a URL cannot be folded across YAML lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
