### PR TITLE
Tag a forum post with its status and its severity

### DIFF
--- a/docs/sources/manage/notify/discord/index.md
+++ b/docs/sources/manage/notify/discord/index.md
@@ -75,9 +75,14 @@ Connect a **forum channel** and each alert group becomes its own post rather tha
 discussion lands beside the card, and the channel list becomes a list of open alerts. Nothing extra to configure —
 OnCall reads the channel's type when you connect it and behaves accordingly.
 
-If the forum has tags named **Alert**, **Warning**, **Acknowledged**, **Silenced** or **Resolved**, OnCall applies
-the matching one and keeps it current, which turns the sidebar into a triage view you can filter. Tags you do not
-create are simply not applied. Create them with the same names to opt in; rename them and OnCall stops.
+If the forum has tags named after a status — **Firing**, **Acknowledged**, **Silenced**, **Resolved** — or after a
+severity — **Critical**, **Warning**, **Info** — OnCall applies the matching ones and keeps them current, which turns
+the sidebar into a triage view you can filter. Tags you do not create are simply not applied. Create them with the
+same names to opt in; rename them and OnCall stops.
+
+Decoration around the name is ignored, so tags can read the way you want them to in Discord: **🔥 Firing**,
+**Resolved ✅** and **Status: 🔥 Firing** all match the firing status, and **Severity: 🚨 Critical** matches a
+critical one.
 
 OnCall reads the forum's tags when you connect the channel, so re-connect it after adding or renaming any. Deleting
 a tag that OnCall still has in that list leaves posts untagged rather than erroring — Discord accepts an unknown tag
@@ -102,10 +107,10 @@ This is deliberately only the loud part. Reaching the right people is still the 
 their own notification policies, so that who gets woken respects who is actually on call. Nothing is posted if the
 alert group has already been acknowledged, silenced or resolved by the time the step runs.
 
-## Split alerts from warnings
+## Split critical alerts from the rest
 
-A route also chooses how loud its alert groups read. Set it to **⚠️ Warning** and a still-open group from that route
-is amber rather than red:
+A route also chooses how loud its alert groups read: **🚨 Critical**, **⚠️ Warning** or **ℹ️ Info**. Set it to
+warning and a still-open group from that route is amber rather than red:
 
 ![A warning alert group, amber rather than red](img/alert-warning.png)
 

--- a/docs/sources/manage/notify/discord/index.md
+++ b/docs/sources/manage/notify/discord/index.md
@@ -84,6 +84,10 @@ Decoration around the name is ignored, so tags can read the way you want them to
 **Resolved ✅** and **Status: 🔥 Firing** all match the firing status, and **Severity: 🚨 Critical** matches a
 critical one.
 
+A forum set up against an earlier version has a tag named **Alert**, which nothing is named any more: rename it to
+**Firing** or **Critical**, whichever you meant it to be. Until you do, its posts keep whichever tag they were last
+given — an unmatched name leaves a post's tags alone rather than clearing them.
+
 OnCall reads the forum's tags when you connect the channel, so re-connect it after adding or renaming any. Deleting
 a tag that OnCall still has in that list leaves posts untagged rather than erroring — Discord accepts an unknown tag
 id and applies nothing.

--- a/engine/apps/discord/alert_group_representative.py
+++ b/engine/apps/discord/alert_group_representative.py
@@ -113,7 +113,7 @@ class AlertGroupDiscordRepresentative(AlertGroupAbstractRepresentative):
                 ).first()
                 client.update_thread(
                     thread_id=discord_message.thread_id,
-                    applied_tags=channel.tag_ids_for(renderer.state_tag_name()) if channel else None,
+                    applied_tags=channel.tag_ids_for(renderer.tag_names()) if channel else None,
                     archived=False,
                 )
                 client.update_message(

--- a/engine/apps/discord/alert_rendering.py
+++ b/engine/apps/discord/alert_rendering.py
@@ -44,21 +44,25 @@ DASHBOARD_INTEGRATIONS = (
     "legacy_alertmanager",
 )
 
-# How a card reads for each state an alert group can be in: the emoji leads the title so a channel list shows the
-# current state without opening anything, and the colour is the embed's left border.
-ALERT, WARNING, ACKNOWLEDGED, SILENCED, RESOLVED = "alert", "warning", "acknowledged", "silenced", "resolved"
+# The status an alert group is in, named the way OnCall names it everywhere else.
+FIRING, ACKNOWLEDGED, SILENCED, RESOLVED = "firing", "acknowledged", "silenced", "resolved"
+
+# What a route may declare a still-open alert group to be, in the words alerting labels already use. Severity
+# belongs to the route rather than to the payload, because which label means "wake somebody" differs per deployment
+# and OnCall already asks a route to decide where an alert goes and who it pages.
+CRITICAL, WARNING, INFO = "critical", "warning", "info"
+SEVERITIES = (CRITICAL, WARNING, INFO)
+
+# How a card reads: the emoji leads the title so a channel list shows where a group stands without opening anything,
+# and the colour is the embed's left border. A firing group reads by its severity, any other status by itself.
 CARD_STYLE = {
-    ALERT: ("🚨", 0xA30200),
+    CRITICAL: ("🚨", 0xA30200),
     WARNING: ("⚠️", 0xE67E22),
+    INFO: ("ℹ️", 0x3274D9),
     ACKNOWLEDGED: ("🟡", 0xDAA038),
     SILENCED: ("🔕", 0xDDDDDD),
     RESOLVED: ("✅", 0x2EB886),
 }
-
-# What a route may declare an alert group to be. Severity says how loud a still-open group reads; it is a property of
-# the route rather than of the payload, because which label means "wake somebody" differs per deployment and OnCall
-# already asks a route to decide where an alert goes and who it pages.
-SEVERITIES = (ALERT, WARNING)
 
 
 def truncate(value: str, limit: int, notice: str = "…") -> str:
@@ -90,7 +94,7 @@ def route_config(alert_group: AlertGroup) -> dict:
 
 def route_severity(alert_group: AlertGroup) -> str:
     severity = route_config(alert_group).get("severity")
-    return severity if severity in SEVERITIES else ALERT
+    return severity if severity in SEVERITIES else CRITICAL
 
 
 def route_escalation_role(alert_group: AlertGroup) -> typing.Optional[str]:
@@ -98,16 +102,22 @@ def route_escalation_role(alert_group: AlertGroup) -> typing.Optional[str]:
     return route_config(alert_group).get("role") or None
 
 
-def card_state(alert_group: AlertGroup) -> str:
-    # An acknowledgement outranks severity: once somebody owns the group, who owns it is the more useful thing for
-    # the channel to show.
+def card_status(alert_group: AlertGroup) -> str:
+    """Where the group stands, in OnCall's own words."""
     if alert_group.resolved:
         return RESOLVED
     if alert_group.acknowledged:
         return ACKNOWLEDGED
     if alert_group.silenced:
         return SILENCED
-    return route_severity(alert_group)
+    return FIRING
+
+
+def card_style(alert_group: AlertGroup) -> tuple:
+    # A status outranks severity: once somebody owns the group, or it is done, that is the more useful thing for the
+    # channel to show than how loudly it arrived.
+    status = card_status(alert_group)
+    return CARD_STYLE[route_severity(alert_group) if status == FIRING else status]
 
 
 class AlertDiscordTemplater(AlertTemplater):
@@ -175,8 +185,7 @@ class AlertGroupDiscordRenderer(AlertGroupBaseRenderer):
 
     def render_alert_group_message(self) -> dict:
         """The whole Discord message for an alert group: one embed, one row of buttons."""
-        state = card_state(self.alert_group)
-        emoji, color = CARD_STYLE[state]
+        emoji, color = card_style(self.alert_group)
 
         embed = self.alert_renderer.render_alert_embed()
         embed["title"] = truncate(f"{emoji} {embed['title']}", EMBED_TITLE_LIMIT)
@@ -211,7 +220,7 @@ class AlertGroupDiscordRenderer(AlertGroupBaseRenderer):
         sees how long the alert has been open without subtracting timestamps by hand.
         """
         alert_group = self.alert_group
-        lines = [f"{CARD_STYLE[ALERT][0]} Fired {stamp(alert_group.started_at)}"]
+        lines = [f"{CARD_STYLE[route_severity(alert_group)][0]} Fired {stamp(alert_group.started_at)}"]
 
         if alert_group.acknowledged and alert_group.acknowledged_at:
             lines.append(
@@ -326,7 +335,7 @@ class DiscordMessageRenderer:
 
     def render_thread_name(self) -> str:
         """What a forum post is called. Discord fixes this at creation, so it carries the alert's identity and
-        leaves current state to the card and the post's tag.
+        leaves where it stands to the card and the post's tags.
 
         The number is what distinguishes two posts about similarly named alerts, so the title is trimmed to leave
         room for it rather than the pair being trimmed together — which would drop the number off a long title and
@@ -337,6 +346,7 @@ class DiscordMessageRenderer:
         suffix = f" · #{self.alert_group.inside_organization_number}"
         return truncate(title, THREAD_NAME_LIMIT - len(suffix)) + suffix
 
-    def state_tag_name(self) -> str:
-        """The forum tag this alert group should carry, matched against the forum's tags by name."""
-        return card_state(self.alert_group).capitalize()
+    def tag_names(self) -> list:
+        """The forum tags this alert group should carry, matched against the forum's tags by name: where it stands,
+        and how loudly it arrived."""
+        return [card_status(self.alert_group).capitalize(), route_severity(self.alert_group).capitalize()]

--- a/engine/apps/discord/models/channel.py
+++ b/engine/apps/discord/models/channel.py
@@ -9,6 +9,14 @@ from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsTypePlu
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
 
 
+def _tag_key(name: str) -> str:
+    """A forum tag matched on the letters of its value alone, so the decoration a forum owner puts around a
+    state — an emoji, a label they group their tags under — still counts as the tag it reads as:
+    "🔥 Alert", "Resolved ✅" and "Status: 🔥 Alert" all match the alert state."""
+    value = name.rpartition(":")[2]
+    return "".join(character for character in value.casefold() if character.isalnum())
+
+
 def generate_public_primary_key_for_discord_channel():
     prefix = "DC"
     new_public_primary_key = generate_public_primary_key(prefix)
@@ -58,11 +66,11 @@ class DiscordChannel(models.Model):
 
         return self.channel_type == FORUM_CHANNEL
 
-    def tag_ids_for(self, name: str) -> typing.Optional[list]:
-        """The forum tag matching a card state, if the forum happens to have one by that name."""
-        by_name = {key.casefold(): value for key, value in (self.available_tags or {}).items()}
-        tag_id = by_name.get(name.casefold())
-        return [tag_id] if tag_id else None
+    def tag_ids_for(self, names: list) -> typing.Optional[list]:
+        """The forum tags matching a card's status and severity, whichever of them the forum happens to have."""
+        by_name = {_tag_key(key): value for key, value in (self.available_tags or {}).items()}
+        tag_ids = [by_name[key] for key in map(_tag_key, names) if key in by_name]
+        return tag_ids or None
 
     @classmethod
     def get_channel_for_alert_group(cls, alert_group: AlertGroup) -> typing.Optional["DiscordChannel"]:

--- a/engine/apps/discord/tasks.py
+++ b/engine/apps/discord/tasks.py
@@ -85,7 +85,7 @@ def on_create_alert_async(self, alert_pk):
                             channel_id=discord_channel.channel_id,
                             name=name,
                             data=payload,
-                            applied_tags=discord_channel.tag_ids_for(renderer.state_tag_name()),
+                            applied_tags=discord_channel.tag_ids_for(renderer.tag_names()),
                         ).message_id
                     discord_message = DiscordAPIMessage(message_id=thread_id, channel_id=discord_channel.channel_id)
                 else:

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -41,7 +41,7 @@ def test_render_firing_alert_group(make_rendered_message):
 
     embed = payload["embeds"][0]
     assert embed["title"].startswith("🚨")
-    assert embed["color"] == CARD_STYLE["alert"][1]
+    assert embed["color"] == CARD_STYLE["critical"][1]
     assert button_labels(payload) == ["Acknowledge", "Resolve", "Add note", "OnCall"]
 
 
@@ -130,8 +130,9 @@ def test_templater_fixes_up_the_shared_web_defaults(
     "notification_backends,emoji",
     [
         ({"DISCORD": {"severity": "warning", "enabled": True}}, "⚠️"),
-        ({"DISCORD": {"severity": "alert", "enabled": True}}, "🚨"),
-        # A route that says nothing about severity, or says something unknown, is an alert.
+        ({"DISCORD": {"severity": "info", "enabled": True}}, "ℹ️"),
+        ({"DISCORD": {"severity": "critical", "enabled": True}}, "🚨"),
+        # A route that says nothing about severity, or says something unknown, is critical.
         ({"DISCORD": {"enabled": True}}, "🚨"),
         ({"DISCORD": {"severity": "whatever", "enabled": True}}, "🚨"),
         (None, "🚨"),

--- a/engine/apps/discord/tests/test_backend.py
+++ b/engine/apps/discord/tests/test_backend.py
@@ -162,7 +162,7 @@ def test_relinking_an_account_moves_it_off_the_previous_user(make_organization_a
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("severity", ["alert", "warning"])
+@pytest.mark.parametrize("severity", ["critical", "warning", "info"])
 def test_validate_channel_filter_severity(make_organization, severity):
     organization = make_organization()
 

--- a/engine/apps/discord/tests/test_client.py
+++ b/engine/apps/discord/tests/test_client.py
@@ -106,7 +106,7 @@ def test_get_channel_reads_a_forum_and_its_tags():
             "guild_id": "789",
             "name": "incidents",
             "type": FORUM_CHANNEL,
-            "available_tags": [{"id": "111", "name": "Alert"}, {"id": "222", "name": "Resolved"}],
+            "available_tags": [{"id": "111", "name": "Firing"}, {"id": "222", "name": "Resolved"}],
         },
         status=200,
     )
@@ -114,7 +114,7 @@ def test_get_channel_reads_a_forum_and_its_tags():
     channel = DiscordClient().get_channel(channel_id="123")
 
     assert channel.is_forum
-    assert channel.available_tags == {"Alert": "111", "Resolved": "222"}
+    assert channel.available_tags == {"Firing": "111", "Resolved": "222"}
 
 
 @pytest.mark.django_db

--- a/engine/apps/discord/tests/test_forum.py
+++ b/engine/apps/discord/tests/test_forum.py
@@ -12,7 +12,7 @@ from apps.discord.client import DiscordMessage as DiscordAPIMessage
 from apps.discord.models import DiscordMessage
 from apps.discord.tasks import on_create_alert_async
 
-TAGS = {"Alert": "111", "Acknowledged": "222", "Resolved": "333"}
+TAGS = {"Firing": "111", "Acknowledged": "222", "Resolved": "333", "Critical": "444"}
 
 
 @pytest.fixture()
@@ -59,7 +59,8 @@ def test_an_alert_group_becomes_a_forum_post(make_forum, make_alert_for):
     _, kwargs = create_thread.call_args
     assert kwargs["channel_id"] == channel.channel_id
     assert kwargs["name"].endswith(f"#{alert_group.inside_organization_number}")
-    assert kwargs["applied_tags"] == ["111"]
+    # Where the group stands, and how loudly it arrived.
+    assert kwargs["applied_tags"] == ["111", "444"]
     assert kwargs["data"]["embeds"]
 
     # The post is the message: a thread and its first message share an id, and the placement remembers the forum it
@@ -82,6 +83,22 @@ def test_a_forum_without_matching_tags_still_posts(make_forum, make_alert_for):
         on_create_alert_async(alert.pk)
 
     assert create_thread.call_args[1]["applied_tags"] is None
+
+
+@pytest.mark.django_db
+def test_a_decorated_tag_still_matches_what_it_names(make_forum, make_alert_for):
+    """Forum owners dress their tags up — an emoji, a label they group them under — and the tag still reads as
+    the status or severity it names."""
+    organization, _ = make_forum(available_tags={"Status: 🔥 Firing": "999", "Severity: 🚨 Critical": "888"})
+    _, alert = make_alert_for(organization)
+
+    with patch(
+        "apps.discord.tasks.DiscordClient.create_thread",
+        return_value=DiscordAPIMessage(message_id="1300000000000000009", channel_id="1300000000000000009"),
+    ) as create_thread:
+        on_create_alert_async(alert.pk)
+
+    assert create_thread.call_args[1]["applied_tags"] == ["999", "888"]
 
 
 @pytest.mark.django_db
@@ -187,7 +204,7 @@ def test_updating_a_post_unarchives_and_retags_it_first(make_forum, make_alert_f
     # Discord refuses an edit to an archived post, so unarchiving happens in the same call that retags it.
     assert update_thread.call_args[1] == {
         "thread_id": "1300000000000000009",
-        "applied_tags": ["222"],
+        "applied_tags": ["222", "444"],
         "archived": False,
     }
     assert update_message.call_args[1]["channel_id"] == "1300000000000000009"

--- a/grafana-plugin/src/containers/AlertRules/parts/connectors/DiscordConnector.tsx
+++ b/grafana-plugin/src/containers/AlertRules/parts/connectors/DiscordConnector.tsx
@@ -16,8 +16,9 @@ import { useStore } from 'state/useStore';
 import { getConnectorsStyles } from './Connectors.styles';
 
 const SEVERITY_OPTIONS = [
-  { value: 'alert', label: '🚨 Alert' },
+  { value: 'critical', label: '🚨 Critical' },
   { value: 'warning', label: '⚠️ Warning' },
+  { value: 'info', label: 'ℹ️ Info' },
 ];
 
 interface DiscordConnectorProps {
@@ -53,11 +54,11 @@ export const DiscordConnector = observer((props: DiscordConnectorProps) => {
     });
   }, []);
 
-  // How loud a still-open alert group from this route reads in Discord: an alert is red, a warning amber. Which
-  // payloads count as either is what the route itself already decides.
+  // How loud a still-open alert group from this route reads in Discord: critical is red, warning amber, info blue.
+  // Which payloads count as which is what the route itself already decides.
   const handleSeverityChange = useCallback((option: SelectableValue<string>) => {
     alertReceiveChannelStore.saveChannelFilter(channelFilterId, {
-      notification_backends: { DISCORD: { severity: option?.value || 'alert' } },
+      notification_backends: { DISCORD: { severity: option?.value || 'critical' } },
     });
   }, []);
 
@@ -102,7 +103,7 @@ export const DiscordConnector = observer((props: DiscordConnectorProps) => {
           <Select
             className={cx('select', 'control')}
             options={SEVERITY_OPTIONS}
-            value={channelFilter.notification_backends?.DISCORD?.severity || 'alert'}
+            value={channelFilter.notification_backends?.DISCORD?.severity || 'critical'}
             onChange={handleSeverityChange}
             aria-label="Discord severity"
           />

--- a/grafana-plugin/src/containers/AlertRules/parts/connectors/DiscordConnector.tsx
+++ b/grafana-plugin/src/containers/AlertRules/parts/connectors/DiscordConnector.tsx
@@ -21,6 +21,13 @@ const SEVERITY_OPTIONS = [
   { value: 'info', label: 'ℹ️ Info' },
 ];
 
+// A route saved before these were the words — or saying nothing at all — reads as critical, the way the engine
+// reads it, rather than leaving an empty box behind.
+const severityOf = (channelFilter: ChannelFilter) => {
+  const severity = channelFilter.notification_backends?.DISCORD?.severity;
+  return SEVERITY_OPTIONS.some((option) => option.value === severity) ? severity : 'critical';
+};
+
 interface DiscordConnectorProps {
   channelFilterId: ChannelFilter['id'];
 }
@@ -103,7 +110,7 @@ export const DiscordConnector = observer((props: DiscordConnectorProps) => {
           <Select
             className={cx('select', 'control')}
             options={SEVERITY_OPTIONS}
-            value={channelFilter.notification_backends?.DISCORD?.severity || 'critical'}
+            value={severityOf(channelFilter)}
             onChange={handleSeverityChange}
             aria-label="Discord severity"
           />


### PR DESCRIPTION
A forum tag is matched on the letters of what it names, so the decoration a forum owner puts around it — an emoji, a label they group tags under — no longer stops it matching. `🔥 Firing`, `Resolved ✅` and `Status: 🔥 Firing` all read as the firing status.

A post now carries both of the things worth filtering a channel list by, where the forum has tags for them: **where the group stands**, and **how loudly it arrived**. A forum with only status tags behaves exactly as before.

## Terminology

Status is named the way OnCall names it everywhere else — **Firing**, **Acknowledged**, **Silenced**, **Resolved** — and severity the way alerting labels already name it: **Critical**, **Warning**, **Info**.

Severity was `alert` or `warning`, which reused "alert" for both a status and a severity, and offered no word for the alerts nobody needs to look at today. A firing card reads by its severity (🚨 red, ⚠️ amber, ℹ️ blue); any other status reads by itself, so acknowledging still turns a card 🟡 whichever route it came in on.

## Upgrading

No migration is needed. A route saved as `warning` still means warning, and a route saved as `alert` reads as critical — which is what it meant — so nothing changes how it renders. The route editor shows critical for such a route rather than an empty box, and writes the new value the next time the route is saved.

A forum set up against an earlier version has a tag named **Alert**, which nothing is named any more. Rename it to **Firing** or **Critical**, whichever you meant it to be, and re-connect the channel. Until then its posts keep whichever tag they were last given — an unmatched name leaves a post's tags alone rather than clearing them. The docs say so too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)