### PR TITLE
fix: post follow-ups into the forum post, not at the forum

### DIFF
--- a/engine/apps/discord/alert_group_representative.py
+++ b/engine/apps/discord/alert_group_representative.py
@@ -8,6 +8,7 @@ from apps.discord.alert_rendering import DiscordMessageRenderer
 from apps.discord.client import DiscordClient
 from apps.discord.exceptions import DiscordAPIException, DiscordAPITokenInvalid
 from apps.discord.tasks import on_alert_group_action_triggered_async, on_create_alert_async
+from apps.discord.utils import beside_card
 
 logger = logging.getLogger(__name__)
 
@@ -77,11 +78,8 @@ class AlertGroupDiscordRepresentative(AlertGroupAbstractRepresentative):
             # The role being escalated to, and nothing else the alert text happens to name.
             "allowed_mentions": {"parse": [], "roles": [role]},
         }
-        if discord_message.thread_id:
-            channel_id = discord_message.thread_id
-        else:
-            channel_id = discord_message.channel_id
-            payload["message_reference"] = {"message_id": discord_message.message_id, "fail_if_not_exists": False}
+        channel_id, reference = beside_card(discord_message)
+        payload.update(reference)
 
         try:
             DiscordClient().create_message(

--- a/engine/apps/discord/shifts.py
+++ b/engine/apps/discord/shifts.py
@@ -86,15 +86,22 @@ def announce_shift_starts_for_schedule(schedule_pk) -> None:
         if not names:
             continue
 
+        payload = {
+            "content": f"📅 {names} — your **{schedule.name}** on-call shift just started.",
+            # A schedule name is user-supplied text, so only the users going on call may be pinged.
+            "allowed_mentions": {"parse": [], "users": user_ids},
+        }
+
         try:
-            DiscordClient().create_message(
-                channel_id=channel.channel_id,
-                data={
-                    "content": f"📅 {names} — your **{schedule.name}** on-call shift just started.",
-                    # A schedule name is user-supplied text, so only the users going on call may be pinged.
-                    "allowed_mentions": {"parse": [], "users": user_ids},
-                },
-            )
+            if channel.is_forum:
+                # A forum channel takes posts, not messages, so the announcement becomes a post of its own.
+                DiscordClient().create_thread(
+                    channel_id=channel.channel_id,
+                    name=f"📅 {schedule.name} — shift change",
+                    data=payload,
+                )
+            else:
+                DiscordClient().create_message(channel_id=channel.channel_id, data=payload)
         except DiscordAPITokenInvalid:
             logger.error(f"Discord bot token is invalid, could not announce shifts for schedule {schedule_pk}")
             return

--- a/engine/apps/discord/tasks.py
+++ b/engine/apps/discord/tasks.py
@@ -10,6 +10,7 @@ from apps.discord.client import DiscordClient
 from apps.discord.client import DiscordMessage as DiscordAPIMessage
 from apps.discord.exceptions import DiscordAPIException, DiscordAPITokenInvalid
 from apps.discord.models import DiscordChannel, DiscordMessage
+from apps.discord.utils import beside_card
 from apps.user_management.models import User
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 from common.utils import OkToRetry, task_lock
@@ -197,17 +198,18 @@ def notify_user_about_alert_async(user_pk, alert_group_pk, notification_policy_p
     else:
         content = f"{templated_alert.title}\nInviting {discord_user.mention_username} to look at the alert group."
 
+    channel_id, reference = beside_card(discord_message)
     payload = {
         "content": content,
-        "message_reference": {"message_id": discord_message.message_id, "fail_if_not_exists": False},
         # An alert annotation is attacker-adjacent text, so a stray @everyone in one must never resolve: only the
         # user being invited is allowed to be pinged.
         "allowed_mentions": {"parse": [], "users": [discord_user.discord_user_id] if discord_user else []},
+        **reference,
     }
 
     try:
         DiscordClient().create_message(
-            channel_id=discord_message.channel_id,
+            channel_id=channel_id,
             data=payload,
             # Same reason as the alert group card: the log record is written after the post, and a retry in between
             # must not page the user twice.

--- a/engine/apps/discord/tests/test_backend.py
+++ b/engine/apps/discord/tests/test_backend.py
@@ -111,6 +111,24 @@ def test_notify_user_mentions_only_that_user(make_notification, make_discord_use
 
 
 @pytest.mark.django_db
+def test_notify_user_in_a_forum_pings_inside_the_post(make_notification, make_discord_user):
+    """Discord refuses a message addressed to a forum channel, so the ping has to go into the post itself."""
+    user, alert_group, notification_policy = make_notification()
+    make_discord_user(user)
+    placement = alert_group.discord_messages.first()
+    placement.thread_id = "1300000000000000777"
+    placement.save(update_fields=["thread_id"])
+
+    with patch("apps.discord.tasks.DiscordClient.create_message") as create_message:
+        notify_user_about_alert_async(user.pk, alert_group.pk, notification_policy.pk)
+
+    _, kwargs = create_message.call_args
+    assert kwargs["channel_id"] == placement.thread_id
+    # Inside the post there is nothing to quote: the card is the post.
+    assert "message_reference" not in kwargs["data"]
+
+
+@pytest.mark.django_db
 def test_notify_unlinked_user_is_logged_as_failed(make_notification):
     user, alert_group, notification_policy = make_notification()
 

--- a/engine/apps/discord/tests/test_shifts.py
+++ b/engine/apps/discord/tests/test_shifts.py
@@ -5,6 +5,7 @@ import pytest
 from django.core.cache import cache
 from django.utils import timezone
 
+from apps.discord.client import FORUM_CHANNEL
 from apps.discord.exceptions import DiscordAPIException
 from apps.discord.shifts import announce_shift_starts_for_all_schedules, announce_shift_starts_for_schedule
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleWeb
@@ -55,6 +56,24 @@ def test_shift_start_is_announced_once(make_schedule_with_shift, make_discord_ch
     assert discord_user.mention_username in kwargs["data"]["content"]
     assert "Primary" in kwargs["data"]["content"]
     assert kwargs["data"]["allowed_mentions"] == {"parse": [], "users": [discord_user.discord_user_id]}
+
+
+@pytest.mark.django_db
+def test_forum_announcement_opens_a_post(make_schedule_with_shift, make_discord_channel, make_discord_user):
+    """A forum channel takes posts, not messages, so an announcement there has to open one."""
+    organization, user, schedule = make_schedule_with_shift()
+    channel = make_discord_channel(organization=organization, is_default_channel=True, channel_type=FORUM_CHANNEL)
+    discord_user = make_discord_user(user)
+
+    with patch("apps.discord.shifts.DiscordClient.create_thread") as create_thread:
+        with patch("apps.discord.shifts.DiscordClient.create_message") as create_message:
+            announce_shift_starts_for_schedule(schedule.pk)
+
+    create_message.assert_not_called()
+    _, kwargs = create_thread.call_args
+    assert kwargs["channel_id"] == channel.channel_id
+    assert "Primary" in kwargs["name"]
+    assert discord_user.mention_username in kwargs["data"]["content"]
 
 
 @pytest.mark.django_db

--- a/engine/apps/discord/utils.py
+++ b/engine/apps/discord/utils.py
@@ -15,6 +15,20 @@ logger = logging.getLogger(__name__)
 VERIFICATION_CODE_TTL = datetime.timedelta(minutes=10)
 
 
+def beside_card(discord_message) -> typing.Tuple[str, dict]:
+    """Where a follow-up to a card goes, and what it takes to sit beside it.
+
+    A forum card is a post, so a follow-up is just a message in that post. A card in a text channel shares the
+    channel with everything else, so a follow-up has to quote it to read as a reply. Posting to a forum channel
+    itself is not a thing Discord allows at all ("Cannot send messages in a non-text channel").
+    """
+    if discord_message.thread_id:
+        return discord_message.thread_id, {}
+    return discord_message.channel_id, {
+        "message_reference": {"message_id": discord_message.message_id, "fail_if_not_exists": False}
+    }
+
+
 def create_verification_code(user: User) -> str:
     """A short-lived proof that whoever holds it is signed in to OnCall as `user`.
 


### PR DESCRIPTION
Found while wiring the production forums up to page on-call: **a linked user could never be pinged in a forum channel.**

Discord refuses a message addressed to a forum channel:

```text
POST /channels/{forum_id}/messages  -> 400 {"message": "Cannot send messages in a non-text channel", "code": 50008}
POST /channels/{thread_id}/messages -> 200
```

(verified against the live API, not inferred)

Two paths sent one there anyway:

- **the on-call ping.** `notify_user_about_alert_async` addressed `discord_message.channel_id`, which for a forum placement is the forum, not the post. So `notify_by=DISCORD` in a user's notification policy silently never arrived — and since 400 isn't in the swallowed set, the task raised and retried indefinitely.
- **the shift-start announcement.** It posts to the default channel, so it breaks as soon as that channel is a forum, which is now the case in production.

The escalation-to-role path already handled this correctly, so rather than repeat the branch a third time the rule moves into one `beside_card` helper the two reply paths share: inside a post there is nothing to quote, in a text channel the follow-up quotes the card to read as a reply. A shift announcement has no card to sit beside, so in a forum it opens a post of its own.

Both new tests fail against the previous code (`assert '100000004000000000' == '1300000000000000777'`), and the existing forum-escalation test also guards the shared helper. 116 passed locally against MySQL + Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)