### PR TITLE
feat: give the card's labels and annotations headings and bullets

### DIFF
--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -491,21 +491,23 @@ def test_a_card_keeps_every_label_and_drops_what_is_said_twice(integration):
     assert "Synthetic test failed two consecutive runs." in rendered
     # One per line, named, so a reader can scan them rather than unpick a wrapped line of pairs.
     lines = rendered.splitlines()
+    assert "**Labels**" in lines
     for label in (
-        "name: backups-tor",
-        "cluster: assets-fra1-prod",
-        "kind: PlaywrightTest",
-        "service: backups",
-        "team: databases",
+        "- name: `backups-tor`",
+        "- cluster: `assets-fra1-prod`",
+        "- kind: `PlaywrightTest`",
+        "- service: `backups`",
+        "- team: `databases`",
     ):
-        assert label in lines, f"{label} should be a line of its own"
-    # An annotation of the sender's own, and a runbook.
-    assert "impact: backups unverified" in lines
+        assert label in lines, f"{label} should be a bullet of its own"
+    # An annotation of the sender's own, under its own heading, and a runbook.
+    assert "**Annotations**" in lines
+    assert "- impact: `backups unverified`" in lines
     assert "https://runbooks.example/synthetics" in rendered
 
     # alertname is the card's title and severity is its title emoji and its tag.
-    assert "alertname: " not in rendered
-    assert "severity: " not in rendered
+    assert "alertname:" not in rendered
+    assert "severity:" not in rendered
     # Grafana reserves the double-underscore names for itself and hides them in its own UI. It uses them for
     # labels as well as annotations, which is what the live cards showed.
     for reserved in ("__alert_rule_uid__", "__alert_rule_namespace_uid__", "__orgId__", "__values__"):
@@ -530,7 +532,7 @@ def test_a_card_says_something_when_the_alert_carries_no_annotations():
         integration_name="Alertmanager",
     )
 
-    assert "instance: localhost:8082" in rendered.splitlines()
+    assert "- instance: `localhost:8082`" in rendered.splitlines()
 
 
 @pytest.mark.django_db
@@ -622,9 +624,9 @@ def test_a_card_reads_a_legacy_payload_too(integration):
 
     lines = rendered.splitlines()
     assert "Instance is down" in lines
-    assert "instance: localhost:8082" in lines
-    assert "job: node" in lines
-    assert "impact: checkout unavailable" in lines
+    assert "- instance: `localhost:8082`" in lines
+    assert "- job: `node`" in lines
+    assert "- impact: `checkout unavailable`" in lines
     # Left to the Dashboard button, which reads the same top-level annotations.
     assert "dashboard_url" not in rendered
 
@@ -669,9 +671,9 @@ def test_value_string_survives_when_there_is_no_values_to_read_instead(integrati
         integration_name="Alertmanager",
     )
 
-    assert "value_string: [ var='A' value=42 ]" in without_values.splitlines()
+    assert "- value_string: `[ var='A' value=42 ]`" in without_values.splitlines()
     assert "value_string" not in with_values
-    assert 'values: {"A":42}' in with_values.splitlines()
+    assert '- values: `{"A":42}`' in with_values.splitlines()
 
 
 @pytest.mark.django_db

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -709,3 +709,30 @@ def test_a_legacy_payloads_dashboard_link_still_gets_a_button(
     }
 
     assert buttons["Dashboard"] == "https://grafana.example/d/nodes"
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_value_cannot_break_the_bullet_it_sits_in(integration):
+    """A value is the sender's text. A newline in one would split its bullet, and a backtick would close the
+    code span early, leaving the rest of the card formatted as code."""
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Weird"},
+            "commonLabels": {"multiline": "first line\nsecond line", "ticked": "a `b` c", "plain": "fine"},
+            "commonAnnotations": {"summary": "Something broke", "note": "line one\nline two"},
+        },
+        source_link="",
+        integration_name="Alertmanager",
+    )
+
+    lines = rendered.splitlines()
+    # Whitespace is collapsed, so one entry stays one bullet.
+    assert "- multiline: `first line second line`" in lines
+    assert "- note: `line one line two`" in lines
+    # A value carrying a backtick is left unwrapped rather than altered.
+    assert "- ticked: a `b` c" in lines
+    assert "- plain: `fine`" in lines
+    # Every bullet is still a bullet.
+    for line in lines:
+        assert not line.startswith("second line"), rendered

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -222,8 +222,20 @@ discord_message = """\
    and not key.startswith("__")
    and said.get(key) != value -%}
 {% set _ = said.update({key: value}) -%}
-{% set _ = labels.append(key ~ ": " ~ value) -%}
+{% set _ = labels.append("- " ~ key ~ ": `" ~ value ~ "`") -%}
 {% endfor -%}
+{% endfor -%}
+
+{# The dashboard and runbook links are buttons on the card, so they are not repeated as lines to copy out of.
+   `value_string` is the long form of `values`, dropped only when there is a `values` to read instead of it. -#}
+{% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
+{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
+{% set notes = [] -%}
+{% for key, value in annotations.items()
+   if key not in spoken
+   and not key.startswith("__")
+   and said.get(key) != value -%}
+{% set _ = notes.append("- " ~ key ~ ": `" ~ value ~ "`") -%}
 {% endfor -%}
 
 {% set summary = annotations.get("summary") -%}
@@ -234,21 +246,21 @@ discord_message = """\
 {# Both, when a rule bothered to write both: a summary says what happened and a description says what it means. -#}
 {% if description and description != summary -%}
 {{ description }}
-{% endif %}
+{% endif -%}
+
+{% if labels %}
+**Labels**
 {% for entry in labels -%}
 {{ entry }}
-{% endfor %}
-{# Anything wrapped in double underscores is Grafana's own, reserved and hidden in its own UI. The dashboard and
-   runbook links are buttons on the card, so they are not repeated as lines to copy out of. `value_string` is the
-   long form of `values` — dropped only when there is a `values` to read instead of it. -#}
-{% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
-{% for key, value in annotations.items()
-   if key not in spoken
-   and not key.startswith("__")
-   and said.get(key) != value -%}
-{{ key }}: {{ value }}
 {% endfor -%}
+{% endif -%}
+
+{% if notes %}
+**Annotations**
+{% for entry in notes -%}
+{{ entry }}
+{% endfor -%}
+{% endif -%}
 
 {% if annotations.get("runbook_url") -%}
 [:book: Runbook]({{ annotations.runbook_url }})

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -207,6 +207,14 @@ web_image_url = None
 discord_title = web_title
 
 discord_message = """\
+{% macro bullet(key, value) -%}
+{% set flat = (value | string).split() | join(" ") -%}
+{% if "`" in flat -%}
+- {{ key }}: {{ flat }}
+{%- else -%}
+- {{ key }}: `{{ flat }}`
+{%- endif -%}
+{% endmacro -%}
 {% set groupLabels = payload.get("groupLabels", {}) -%}
 {% set commonLabels = payload.get("commonLabels", {}) -%}
 {# The legacy alertmanager integration puts labels and annotations at the top level instead. -#}
@@ -222,7 +230,7 @@ discord_message = """\
    and not key.startswith("__")
    and said.get(key) != value -%}
 {% set _ = said.update({key: value}) -%}
-{% set _ = labels.append("- " ~ key ~ ": `" ~ value ~ "`") -%}
+{% set _ = labels.append(bullet(key, value)) -%}
 {% endfor -%}
 {% endfor -%}
 
@@ -235,7 +243,7 @@ discord_message = """\
    if key not in spoken
    and not key.startswith("__")
    and said.get(key) != value -%}
-{% set _ = notes.append("- " ~ key ~ ": `" ~ value ~ "`") -%}
+{% set _ = notes.append(bullet(key, value)) -%}
 {% endfor -%}
 
 {% set summary = annotations.get("summary") -%}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -209,6 +209,14 @@ web_image_url = None
 discord_title = web_title
 
 discord_message = """\
+{% macro bullet(key, value) -%}
+{% set flat = (value | string).split() | join(" ") -%}
+{% if "`" in flat -%}
+- {{ key }}: {{ flat }}
+{%- else -%}
+- {{ key }}: `{{ flat }}`
+{%- endif -%}
+{% endmacro -%}
 {% set groupLabels = payload.get("groupLabels", {}) -%}
 {% set commonLabels = payload.get("commonLabels", {}) -%}
 {# The legacy alertmanager integration puts labels and annotations at the top level instead. -#}
@@ -224,7 +232,7 @@ discord_message = """\
    and not key.startswith("__")
    and said.get(key) != value -%}
 {% set _ = said.update({key: value}) -%}
-{% set _ = labels.append("- " ~ key ~ ": `" ~ value ~ "`") -%}
+{% set _ = labels.append(bullet(key, value)) -%}
 {% endfor -%}
 {% endfor -%}
 
@@ -237,7 +245,7 @@ discord_message = """\
    if key not in spoken
    and not key.startswith("__")
    and said.get(key) != value -%}
-{% set _ = notes.append("- " ~ key ~ ": `" ~ value ~ "`") -%}
+{% set _ = notes.append(bullet(key, value)) -%}
 {% endfor -%}
 
 {% set summary = annotations.get("summary") -%}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -224,8 +224,20 @@ discord_message = """\
    and not key.startswith("__")
    and said.get(key) != value -%}
 {% set _ = said.update({key: value}) -%}
-{% set _ = labels.append(key ~ ": " ~ value) -%}
+{% set _ = labels.append("- " ~ key ~ ": `" ~ value ~ "`") -%}
 {% endfor -%}
+{% endfor -%}
+
+{# The dashboard and runbook links are buttons on the card, so they are not repeated as lines to copy out of.
+   `value_string` is the long form of `values`, dropped only when there is a `values` to read instead of it. -#}
+{% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
+{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
+{% set notes = [] -%}
+{% for key, value in annotations.items()
+   if key not in spoken
+   and not key.startswith("__")
+   and said.get(key) != value -%}
+{% set _ = notes.append("- " ~ key ~ ": `" ~ value ~ "`") -%}
 {% endfor -%}
 
 {% set summary = annotations.get("summary") -%}
@@ -236,21 +248,21 @@ discord_message = """\
 {# Both, when a rule bothered to write both: a summary says what happened and a description says what it means. -#}
 {% if description and description != summary -%}
 {{ description }}
-{% endif %}
+{% endif -%}
+
+{% if labels %}
+**Labels**
 {% for entry in labels -%}
 {{ entry }}
-{% endfor %}
-{# Anything wrapped in double underscores is Grafana's own, reserved and hidden in its own UI. The dashboard and
-   runbook links are buttons on the card, so they are not repeated as lines to copy out of. `value_string` is the
-   long form of `values` — dropped only when there is a `values` to read instead of it. -#}
-{% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
-{% for key, value in annotations.items()
-   if key not in spoken
-   and not key.startswith("__")
-   and said.get(key) != value -%}
-{{ key }}: {{ value }}
 {% endfor -%}
+{% endif -%}
+
+{% if notes %}
+**Annotations**
+{% for entry in notes -%}
+{{ entry }}
+{% endfor -%}
+{% endif -%}
 
 {% if annotations.get("runbook_url") -%}
 [:book: Runbook]({{ annotations.runbook_url }})


### PR DESCRIPTION
v1.22.0 put every label and annotation on its own line, with nothing marking where the prose ended and the metadata began. They now sit under a heading each, as bullets, with values in inline code.

A real card, the ArgoCD sync alert:

```text
[production] ArgoCD application cloud-operators/cloud-tor1-prod-monitoring has been Progressing for over 15 minutes.
A sync that never settles is almost always a workload that never becomes Ready: an image that will not pull, a probe that keeps failing, a pod that cannot be scheduled.

**Labels**
- name: `cloud-tor1-prod-monitoring`
- deployment_environment_name: `production`
- grafana_folder: `Infrastructure`
- project: `cloud-operators`
- team: `cloud`

**Annotations**
- datasource_uid: `PBFA97CFB590B2093`
- grafana_state_reason: `NoData`
- ref_id: `A`
```

Annotations get the same treatment as labels. Bulleted labels beside bare annotation lines read as unfinished.

Nothing else changes: the same keys are kept and the same duplicates dropped.

142 tests pass in the Discord suite. black and flake8 clean.