### PR TITLE
fix: part the summary from the description

### DIFF
--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -655,6 +655,22 @@ def test_a_card_says_both_the_summary_and_the_description(integration):
 
 
 @pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_description_alone_starts_the_card(integration):
+    """The blank line parts a description from a summary, so without one there is nothing to part it from."""
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "DiskSpaceLow"},
+            "commonAnnotations": {"description": "Writes will fail within the hour at the current rate."},
+        },
+        source_link="",
+        integration_name="Alertmanager",
+    )
+
+    assert rendered.startswith("Writes will fail within the hour at the current rate.")
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
 def test_value_string_survives_when_there_is_no_values_to_read_instead(integration):
     """It is dropped for being the long form of `values`, so without `values` it is the only form there is."""
     template = import_module(f"config_integrations.{integration}").discord_message

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -648,8 +648,10 @@ def test_a_card_says_both_the_summary_and_the_description(integration):
     )
 
     lines = rendered.splitlines()
-    assert "Disk is nearly full" in lines
-    assert "Writes will fail within the hour at the current rate." in lines
+    summary_at = lines.index("Disk is nearly full")
+    # A blank line between them, or the two read as one run-on paragraph.
+    assert lines[summary_at + 1] == ""
+    assert lines[summary_at + 2] == "Writes will fail within the hour at the current rate."
 
 
 @pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -251,9 +251,11 @@ discord_message = """\
 {% if summary -%}
 {{ summary }}
 {% endif -%}
-{# Both, when a rule bothered to write both: a summary says what happened and a description says what it means.
-   The blank line before it is deliberate: run together, the two read as one run-on paragraph. -#}
-{% if description and description != summary %}
+{# Both, when a rule bothered to write both: a summary says what happened and a description says what it means. -#}
+{% if description and description != summary -%}
+{# Parted from the summary above, when there is one: run together, the two read as one paragraph. -#}
+{% if summary %}
+{% endif -%}
 {{ description }}
 {% endif -%}
 

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -251,8 +251,9 @@ discord_message = """\
 {% if summary -%}
 {{ summary }}
 {% endif -%}
-{# Both, when a rule bothered to write both: a summary says what happened and a description says what it means. -#}
-{% if description and description != summary -%}
+{# Both, when a rule bothered to write both: a summary says what happened and a description says what it means.
+   The blank line before it is deliberate: run together, the two read as one run-on paragraph. -#}
+{% if description and description != summary %}
 {{ description }}
 {% endif -%}
 

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -253,8 +253,9 @@ discord_message = """\
 {% if summary -%}
 {{ summary }}
 {% endif -%}
-{# Both, when a rule bothered to write both: a summary says what happened and a description says what it means. -#}
-{% if description and description != summary -%}
+{# Both, when a rule bothered to write both: a summary says what happened and a description says what it means.
+   The blank line before it is deliberate: run together, the two read as one run-on paragraph. -#}
+{% if description and description != summary %}
 {{ description }}
 {% endif -%}
 

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -253,9 +253,11 @@ discord_message = """\
 {% if summary -%}
 {{ summary }}
 {% endif -%}
-{# Both, when a rule bothered to write both: a summary says what happened and a description says what it means.
-   The blank line before it is deliberate: run together, the two read as one run-on paragraph. -#}
-{% if description and description != summary %}
+{# Both, when a rule bothered to write both: a summary says what happened and a description says what it means. -#}
+{% if description and description != summary -%}
+{# Parted from the summary above, when there is one: run together, the two read as one paragraph. -#}
+{% if summary %}
+{% endif -%}
 {{ description }}
 {% endif -%}
 


### PR DESCRIPTION
A rule writes a summary to say what happened and a description to say what it means. The card printed them on consecutive lines, so they arrived as one run-on paragraph:

```
[db_fra1_self_hosted_11_1] The / filesystem is more than 80 percent full.
This alert starts when less than 20 percent of the filesystem is free for 30 minutes. MySQL stops writes when the disk is full, and a full disk on a primary stops every write in the region.
```

The two now have a blank line between them.

The blank line belongs to the *pair*, not to the description, so it is emitted from an inner condition on the summary rather than from the description's own block. Emitting it from the description block would put a blank line at the top of every card that carries a description and no summary — which the first draft of this PR did.

Applied to both `alertmanager` and `grafana_alerting`, which carry the same block.

## Verification

Rendered both templates directly across every combination:

| summary | description | result |
|---|---|---|
| yes | yes | blank line between them |
| no | yes | card starts with the description, no leading blank |
| yes | no | unchanged, no stray blanks |
| yes | identical to summary | printed once |
| no | no | no leading blank |

Two tests cover it. `test_a_card_says_both_the_summary_and_the_description` asserted only that both lines appear, which passed before and after, so it now asserts the blank line sits between them. `test_a_description_alone_starts_the_card` is new and covers the case above.

Both use `apply_jinja_template`, which returns the render untouched, so a leading newline fails the assertion rather than being stripped on the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEQwALSZPGEKy6JRtgt5wZ