### PR TITLE
fix: register the shift announcement tasks

### DIFF
--- a/engine/apps/discord/tasks.py
+++ b/engine/apps/discord/tasks.py
@@ -15,6 +15,13 @@ from apps.user_management.models import User
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 from common.utils import OkToRetry, task_lock
 
+# Autodiscovery imports `tasks` and nothing else, so a task defined anywhere else in the app is never registered and
+# the beat entry that names it is dropped by the worker. Re-exported here the way apps.mobile_app.tasks does it.
+from apps.discord.shifts import (  # noqa: F401  isort:skip
+    announce_shift_starts_for_all_schedules,
+    announce_shift_starts_for_schedule,
+)
+
 logger = get_task_logger(__name__)
 logger.setLevel(logging.DEBUG)
 

--- a/engine/apps/discord/tests/test_shifts.py
+++ b/engine/apps/discord/tests/test_shifts.py
@@ -158,12 +158,14 @@ def test_the_tasks_are_registered_by_autodiscovery():
         "current_app.loader.import_default_modules();"
         "print(' '.join(current_app.tasks))"
     )
-    result = subprocess.run(
-        [sys.executable, "-c", program],
-        capture_output=True,
-        text=True,
-        env={**os.environ, "DJANGO_SETTINGS_MODULE": settings.SETTINGS_MODULE},
-    )
+    # The child reads DJANGO_SETTINGS_MODULE from the environment, the same as the worker does. pytest-django
+    # leaves `settings.SETTINGS_MODULE` empty, so it is a fallback for a run that has no variable set, never an
+    # override: putting its None in the environment is a TypeError before the child even starts.
+    env = dict(os.environ)
+    if not env.get("DJANGO_SETTINGS_MODULE") and settings.SETTINGS_MODULE:
+        env["DJANGO_SETTINGS_MODULE"] = settings.SETTINGS_MODULE
+
+    result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True, env=env)
 
     assert result.returncode == 0, result.stderr
     registered = set(result.stdout.split())

--- a/engine/apps/discord/tests/test_shifts.py
+++ b/engine/apps/discord/tests/test_shifts.py
@@ -1,7 +1,11 @@
 import datetime
+import os
+import subprocess
+import sys
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -140,3 +144,28 @@ def test_fan_out_skips_organizations_without_a_channel(make_schedule_with_shift,
     with patch("apps.discord.shifts.announce_shift_starts_for_schedule.apply_async") as apply_async:
         announce_shift_starts_for_all_schedules()
     assert (schedule.pk,) in [call.args[0] for call in apply_async.call_args_list]
+
+
+def test_the_tasks_are_registered_by_autodiscovery():
+    """Beat publishes a task by name, and a name the worker does not know is dropped with an error nobody reads.
+
+    Autodiscovery imports each app's `tasks` module and nothing else, so this asks a fresh interpreter what the
+    worker would end up with. Importing the module here instead would register the tasks and prove nothing.
+    """
+    program = (
+        "import django; django.setup();"
+        "from celery import current_app;"
+        "current_app.loader.import_default_modules();"
+        "print(' '.join(current_app.tasks))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "DJANGO_SETTINGS_MODULE": settings.SETTINGS_MODULE},
+    )
+
+    assert result.returncode == 0, result.stderr
+    registered = set(result.stdout.split())
+    assert "apps.discord.shifts.announce_shift_starts_for_all_schedules" in registered
+    assert "apps.discord.shifts.announce_shift_starts_for_schedule" in registered


### PR DESCRIPTION
No on-call shift has ever been announced. Beat has been publishing the task every 10 minutes since the feature shipped, and the worker has been dropping every one:

```
level=INFO  Scheduler: Sending due task announce_shift_starts_for_all_schedules
level=ERROR Received unregistered task of type 'apps.discord.shifts.announce_shift_starts_for_all_schedules'.
KeyError: 'apps.discord.shifts.announce_shift_starts_for_all_schedules'
```

`engine/celery.py` calls a bare `app.autodiscover_tasks()`, which imports each app's `tasks` module and nothing else. The two shift tasks are defined in `apps/discord/shifts.py`, which nothing imports, so they are never registered. Beat only needs the task *name* — a string in `CELERY_BEAT_SCHEDULE` — so it publishes happily to the `discord` queue and the worker has no such name in its registry.

Everything else was correctly configured, which is what made this hard to see: `FEATURE_DISCORD_INTEGRATION_ENABLED` is on, `discord` is in `CELERY_WORKER_QUEUE`, beat is enabled, the route resolves to the right queue, and the beat entry itself is registered.

## Reproduced and confirmed fixed

Against the released `v1.22.3` image with production settings (`settings.hobby`, Discord enabled):

```
before:  shift task scheduled by beat : True
         shift task in worker registry: False
         beat tasks missing from registry: ['apps.discord.shifts.announce_shift_starts_for_all_schedules']

after:   beat tasks missing from registry: none
         both shift tasks registered: True
         routed to queue: {'queue': 'discord'}
```

It was the only one of the 21 beat entries missing from the registry.

## The fix

The tasks are re-exported from `apps/discord/tasks.py`, which is the pattern `apps/mobile_app/tasks/__init__.py` already uses for exactly this reason.

## Why the tests passed

`test_shifts.py` imports the functions and calls them directly:

```python
from apps.discord.shifts import announce_shift_starts_for_all_schedules, announce_shift_starts_for_schedule
```

That covers the behaviour well and the registration not at all — the import in the test file is what loads the module. The worker has no such import.

So the new test asks a **fresh interpreter** what the worker would end up with, rather than importing the module itself:

```python
program = ("import django; django.setup();"
           "from celery import current_app;"
           "current_app.loader.import_default_modules();"
           "print(' '.join(current_app.tasks))")
```

Importing `apps.discord.shifts` in the test to check it would register the tasks and prove nothing, and asserting against `CELERY_BEAT_SCHEDULE` in-process would be vacuous once any other test module has imported them.

## Checks

`isort`, `black` and `flake8` pass with the repo's own configs and pinned versions. I could not run `pytest` locally — the runtime image carries no test dependencies and I have no Python environment for the engine here — so the new test's pytest plumbing is unproven; the program it runs is the one verified above, and CI will confirm the rest. It relies on pytest running from `engine/`, which is what `linting-and-tests.yml` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEQwALSZPGEKy6JRtgt5wZ