### PR TITLE
fix(discord): name each instance a group holds

### DIFF
--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -631,6 +631,84 @@ def test_a_card_does_not_list_the_one_instance_it_already_describes():
     assert rendered.count("The `builds` queue gained 12 failed jobs in an hour.") == 1
 
 
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_lists_the_one_instance_of_a_group_that_says_anything(integration):
+    """Whether a group is listed is decided by how many alerts it holds, not by how many of them had something
+    to say.
+
+    An instance whose labels are all common to the group and whose rule wrote no summary adds no line. Counting
+    lines rather than alerts, a pair like that read as a group of one and threw away the only line naming what
+    had failed.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {
+                "alertname": "Queue has failed jobs",
+                "deployment_region_name": "fra",
+                "team": "cloud",
+            },
+            "commonAnnotations": {"description": "This alert starts when a queue is holding more failed jobs."},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {
+                        "alertname": "Queue has failed jobs",
+                        "deployment_region_name": "fra",
+                        "k8s_cluster_name": "cloud-fra1-prod",
+                        "service_name": "builds",
+                        "team": "cloud",
+                    },
+                    "annotations": {"summary": "The `builds` queue on `cloud-fra1-prod` has failed 2384 more jobs."},
+                },
+                {
+                    "status": "firing",
+                    "labels": {
+                        "alertname": "Queue has failed jobs",
+                        "deployment_region_name": "fra",
+                        "team": "cloud",
+                    },
+                    "annotations": {},
+                },
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert "**Instances**" in lines
+    assert "- The `builds` queue on `cloud-fra1-prod` has failed 2384 more jobs." in lines
+    # The names the group does not share, which no other line on the card carries.
+    for name in ("builds", "cloud-fra1-prod"):
+        assert name in rendered, f"{name} is in no common label and is on no other line"
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_says_an_instance_line_once(integration):
+    """A group whose alerts were all written the same sentence has that sentence in commonAnnotations already,
+    and a list of it repeats one line per alert."""
+    shared = "A queue is holding more failed jobs than it was."
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+            "commonAnnotations": {"summary": shared},
+            "alerts": [
+                {"status": "firing", "labels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+                 "annotations": {"summary": shared}}
+                for _ in range(3)
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+
+    assert rendered.count(shared) == 1
+
+
 @pytest.mark.django_db
 def test_a_dashboard_annotation_becomes_a_button_of_its_own(
     make_organization, make_user_for_organization, make_alert_receive_channel, make_alert_group, make_alert

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -592,7 +592,7 @@ def test_a_card_names_each_instance_a_group_holds(integration):
     )
     lines = rendered.splitlines()
 
-    assert "**Instances**" in lines
+    assert "**Summaries**" in lines
     for instance in (
         "- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour.",
         "- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour.",
@@ -626,7 +626,7 @@ def test_a_card_does_not_list_the_one_instance_it_already_describes():
         integration_name="Grafana Alerting",
     )
 
-    assert "**Instances**" not in rendered.splitlines()
+    assert "**Summaries**" not in rendered.splitlines()
     # Said once, by the summary that a group of one puts in commonAnnotations.
     assert rendered.count("The `builds` queue gained 12 failed jobs in an hour.") == 1
 
@@ -678,7 +678,7 @@ def test_a_card_lists_the_one_instance_of_a_group_that_says_anything(integration
     )
     lines = rendered.splitlines()
 
-    assert "**Instances**" in lines
+    assert "**Summaries**" in lines
     assert "- The `builds` queue on `cloud-fra1-prod` has failed 2384 more jobs." in lines
     # The names the group does not share, which no other line on the card carries.
     for name in ("builds", "cloud-fra1-prod"):
@@ -742,7 +742,7 @@ def test_a_card_names_instances_a_shared_sentence_does_not(integration):
     )
     lines = [line for line in rendered.splitlines() if line.startswith("- ")]
 
-    assert "**Instances**" in rendered.splitlines()
+    assert "**Summaries**" in rendered.splitlines()
     # One line per alert, and each names the instance its sentence did not.
     for region, node in (("fra", "node-1"), ("syd", "node-2"), ("tor", "node-3")):
         assert any(f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines), (
@@ -812,6 +812,56 @@ def test_an_instance_line_does_not_repeat_what_its_summary_already_says(integrat
     assert "- The `domains` queue on `cloud-syd1-prod` has failed 12 more jobs." in lines
     # The labels the sentence already carries are not appended to it.
     assert not any("service_name:" in line for line in lines)
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_keeps_what_the_route_grouped_by_apart_from_what_the_alerts_share(integration):
+    """Two questions, two headings.
+
+    `groupLabels` says why these alerts arrived as one card; `commonLabels` says what they turned out to have in
+    common once they had. Merged under one heading a reader cannot tell which is which, and the label that
+    explains the grouping is buried among labels that merely happen to agree.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            # The default Grafana policy: group_by = [grafana_folder, alertname].
+            "groupLabels": {"grafana_folder": "Utopia", "alertname": "Queue has failed jobs"},
+            "commonLabels": {
+                "alertname": "Queue has failed jobs",
+                "grafana_folder": "Utopia",
+                "deployment_cluster_name": "cloud",
+                "severity": "warning",
+                "team": "cloud",
+            },
+            "commonAnnotations": {"description": "A queue is holding more failed jobs than it was."},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "grafana_folder": "Utopia",
+                               "deployment_cluster_name": "cloud", "severity": "warning", "team": "cloud",
+                               "service_name": service},
+                    "annotations": {"summary": f"The `{service}` queue has failed 12 more jobs."},
+                }
+                for service in ("builds", "domains")
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert "**Group**" in lines
+    assert "**Labels**" in lines
+    group = lines.index("**Group**")
+    labels = lines.index("**Labels**")
+    # What the route grouped by, under Group. alertname is the card's title, so it is not a line.
+    assert "- grafana_folder: `Utopia`" in lines[group:labels]
+    assert not any("alertname:" in line for line in lines)
+    # What they merely share, under Labels, and not repeated under Group.
+    assert "- deployment_cluster_name: `cloud`" in lines[labels:]
+    assert "- team: `cloud`" in lines[labels:]
+    assert rendered.count("grafana_folder") == 1, "a label belongs to one heading, not both"
 
 
 @pytest.mark.django_db

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -535,6 +535,102 @@ def test_a_card_says_something_when_the_alert_carries_no_annotations():
     assert "- instance: `localhost:8082`" in rendered.splitlines()
 
 
+# The default Grafana route groups by grafana_folder and alertname only, so one rule watching many workers in many
+# regions arrives as a single group. service_name differs between the instances, which keeps it out of
+# commonLabels, and each summary is written from it, which keeps every summary out of commonAnnotations.
+QUEUE_FAILURES_PAYLOAD = {
+    "status": "firing",
+    "groupLabels": {"alertname": "Queue has failed jobs"},
+    "commonLabels": {
+        "alertname": "Queue has failed jobs",
+        "deployment_cluster_name": "cloud",
+        "grafana_folder": "Utopia",
+        "severity": "warning",
+        "team": "cloud",
+    },
+    "commonAnnotations": {"description": "This alert starts when a queue is holding more failed jobs than it was."},
+    "alerts": [
+        {
+            "status": "firing",
+            "labels": {
+                "alertname": "Queue has failed jobs",
+                "deployment_region_name": "fra",
+                "k8s_cluster_name": "cloud-fra1-prod",
+                "service_name": "builds",
+                "severity": "warning",
+            },
+            "annotations": {"summary": "The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour."},
+        },
+        {
+            "status": "firing",
+            "labels": {
+                "alertname": "Queue has failed jobs",
+                "deployment_region_name": "syd",
+                "k8s_cluster_name": "cloud-syd1-prod",
+                "service_name": "domains",
+                "severity": "warning",
+            },
+            "annotations": {"summary": "The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour."},
+        },
+    ],
+}
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_names_each_instance_a_group_holds(integration):
+    """A group of many says what is in it.
+
+    The card can only print what the instances share, and what they share is the part that does not identify
+    them. Without a line per instance the reader is told a queue somewhere has failed jobs and not which queue.
+    """
+    config = import_module(f"config_integrations.{integration}")
+    rendered = apply_jinja_template(
+        config.discord_message,
+        payload=QUEUE_FAILURES_PAYLOAD,
+        source_link="https://grafana.example/alerting/list",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert "**Instances**" in lines
+    for instance in (
+        "- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour.",
+        "- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour.",
+    ):
+        assert instance in lines, f"{instance} should be a line of its own"
+    # The names that only the instances carry, which is the whole reason the card lists them.
+    for name in ("builds", "domains", "cloud-fra1-prod", "cloud-syd1-prod"):
+        assert name in rendered, f"{name} is in no common label and would be lost"
+    # What they do share is still said once, above.
+    assert "This alert starts when a queue is holding more failed jobs than it was." in rendered
+    assert "- team: `cloud`" in lines
+
+
+def test_a_card_does_not_list_the_one_instance_it_already_describes():
+    """A group of one has its labels and its summary in the lines above, so a list of it repeats them."""
+    rendered = apply_jinja_template(
+        import_module("config_integrations.grafana_alerting").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs", "service_name": "builds"},
+            "commonLabels": {"alertname": "Queue has failed jobs", "service_name": "builds"},
+            "commonAnnotations": {"summary": "The `builds` queue gained 12 failed jobs in an hour."},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "service_name": "builds"},
+                    "annotations": {"summary": "The `builds` queue gained 12 failed jobs in an hour."},
+                }
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+
+    assert "**Instances**" not in rendered.splitlines()
+    # Said once, by the summary that a group of one puts in commonAnnotations.
+    assert rendered.count("The `builds` queue gained 12 failed jobs in an hour.") == 1
+
+
 @pytest.mark.django_db
 def test_a_dashboard_annotation_becomes_a_button_of_its_own(
     make_organization, make_user_for_organization, make_alert_receive_channel, make_alert_group, make_alert

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -709,6 +709,111 @@ def test_a_card_says_an_instance_line_once(integration):
     assert rendered.count(shared) == 1
 
 
+def _disk_alert(region, node, summary):
+    return {
+        "status": "firing",
+        "labels": {"alertname": "Disk filling", "team": "cloud", "region": region, "instance": node},
+        "annotations": {"summary": summary},
+    }
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_names_instances_a_shared_sentence_does_not(integration):
+    """A summary is prose, not an identity.
+
+    A rule is free to write two instances the same sentence, and then that sentence identifies neither of them.
+    Taking the sentence as the instance's line collapsed the pair into one entry naming no region and no node,
+    so a card reported two full disks as one and named neither.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Disk filling"},
+            "commonLabels": {"alertname": "Disk filling", "team": "cloud"},
+            "commonAnnotations": {"description": "A disk is above its watermark."},
+            "alerts": [
+                _disk_alert("fra", "node-1", "Disk is nearly full."),
+                _disk_alert("syd", "node-2", "Disk is nearly full."),
+                _disk_alert("tor", "node-3", "Root volume is nearly full."),
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = [line for line in rendered.splitlines() if line.startswith("- ")]
+
+    assert "**Instances**" in rendered.splitlines()
+    # One line per alert, and each names the instance its sentence did not.
+    for region, node in (("fra", "node-1"), ("syd", "node-2"), ("tor", "node-3")):
+        assert any(f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines), (
+            f"{region}/{node} is named nowhere on the card"
+        )
+    # The sentence two of them share is still said against each of them, not collapsed into one entry.
+    assert len([line for line in lines if "Disk is nearly full." in line]) == 2
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_names_instances_when_every_summary_is_the_same(integration):
+    """The same defect with every alert written the same sentence, which puts it in commonAnnotations.
+
+    The card says that sentence once at the top. What is left to tell the instances apart is their labels, so a
+    line carries those and not the sentence again.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Disk filling"},
+            "commonLabels": {"alertname": "Disk filling", "team": "cloud"},
+            "commonAnnotations": {"summary": "Disk is nearly full."},
+            "alerts": [
+                _disk_alert("fra", "node-1", "Disk is nearly full."),
+                _disk_alert("syd", "node-2", "Disk is nearly full."),
+                _disk_alert("tor", "node-3", "Disk is nearly full."),
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = [line for line in rendered.splitlines() if line.startswith("- ")]
+
+    for region, node in (("fra", "node-1"), ("syd", "node-2"), ("tor", "node-3")):
+        assert any(f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines), (
+            f"{region}/{node} is named nowhere on the card"
+        )
+    # Said once, at the top, rather than again on every line below it.
+    assert rendered.count("Disk is nearly full.") == 1
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_an_instance_line_does_not_repeat_what_its_summary_already_says(integration):
+    """A rule that names the instance in its summary has said it, and the line does not say it twice."""
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+            "commonAnnotations": {"description": "A queue is holding more failed jobs than it was."},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "team": "cloud",
+                               "service_name": service, "k8s_cluster_name": cluster},
+                    "annotations": {"summary": f"The `{service}` queue on `{cluster}` has failed 12 more jobs."},
+                }
+                for service, cluster in (("builds", "cloud-fra1-prod"), ("domains", "cloud-syd1-prod"))
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = [line for line in rendered.splitlines() if line.startswith("- ")]
+
+    assert "- The `builds` queue on `cloud-fra1-prod` has failed 12 more jobs." in lines
+    assert "- The `domains` queue on `cloud-syd1-prod` has failed 12 more jobs." in lines
+    # The labels the sentence already carries are not appended to it.
+    assert not any("service_name:" in line for line in lines)
+
+
 @pytest.mark.django_db
 def test_a_dashboard_annotation_becomes_a_button_of_its_own(
     make_organization, make_user_for_organization, make_alert_receive_channel, make_alert_group, make_alert

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -266,24 +266,29 @@ discord_message = """\
 {% set instances = [] -%}
 {% for alert in payload.get("alerts", []) -%}
 {% set own = alert.get("annotations", {}).get("summary") -%}
-{% if own -%}
-{% set _ = instances.append((own | string).split() | join(" ")) -%}
-{% else -%}
 {% set apart = [] -%}
+{% if not own -%}
 {% for key, value in alert.get("labels", {}).items()
    if key not in ["alertname", "severity"]
    and not key.startswith("__")
    and commonLabels.get(key) != value -%}
 {% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
 {% endfor -%}
-{% if apart -%}
-{% set _ = instances.append(apart | join(", ")) -%}
 {% endif -%}
+{% if own -%}
+{% set entry = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set entry = apart | join(", ") -%}
+{% endif -%}
+{# Said once: not the summary the card has already printed above, and not another instance's line. -#}
+{% if entry and entry != summary and entry not in instances -%}
+{% set _ = instances.append(entry) -%}
 {% endif -%}
 {% endfor -%}
 
-{# A group of one already says everything it has in the lines above. -#}
-{% if instances | length > 1 %}
+{# A group of one says everything it has in the lines above. A group of many says what is in it, even when only
+   one of them turned out to carry anything of its own: that one line is the only thing naming what failed. -#}
+{% if instances and (payload.get("alerts", []) | length) > 1 %}
 **Instances**
 {% for entry in instances[:20] -%}
 - {{ entry }}

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -207,47 +207,76 @@ web_image_url = None
 discord_title = web_title
 
 discord_message = """\
-{% macro bullet(key, value) -%}
+{# A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels
+   and annotations. `groupLabels`, `commonLabels` and `commonAnnotations` are views Alertmanager derives from
+   them — the part the instances agree on. The legacy integration sends no `alerts` and puts a single instance's
+   labels and annotations at the top level, so it is read here as a group of one and nothing below this block has
+   to know which shape arrived.
+
+   A card says the agreed part once, and names the instances when there is more than one, because what sets them
+   apart is exactly what the agreed part cannot carry. -#}
+{% macro pair(key, value) -%}
 {% set flat = (value | string).split() | join(" ") -%}
 {% if "`" in flat -%}
-- {{ key }}: {{ flat }}
+{{ key }}: {{ flat }}
 {%- else -%}
-- {{ key }}: `{{ flat }}`
+{{ key }}: `{{ flat }}`
 {%- endif -%}
 {% endmacro -%}
-{% set groupLabels = payload.get("groupLabels", {}) -%}
-{% set commonLabels = payload.get("commonLabels", {}) -%}
-{# The legacy alertmanager integration puts labels and annotations at the top level instead. -#}
-{% set annotations = payload.get("commonAnnotations", {}) if payload.get("commonAnnotations") else payload.get("annotations", {}) -%}
-{% set legacyLabels = payload.get("labels", {}) -%}
 
-{# Grafana sends its own identifiers as labels too, wrapped in double underscores the same way. -#}
-{% set said = {} -%}
-{% set labels = [] -%}
-{% for source in [groupLabels, commonLabels, legacyLabels] -%}
+{# alertname titles the card, and severity is its title emoji and its forum tag, so neither is a line on it.
+   Grafana wraps its own identifiers in double underscores and hides them in its own UI. -#}
+{% set said_elsewhere = ["alertname", "severity"] -%}
+{% set instances = payload.get("alerts") or [{"labels": payload.get("labels", {}), "annotations": payload.get("annotations", {})}] -%}
+{% set agreed = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
+{% set shared = {} -%}
+{% for source in [payload.get("groupLabels", {}), payload.get("commonLabels", {}), payload.get("labels", {})] -%}
 {% for key, value in source.items()
-   if key not in ["alertname", "severity"]
-   and not key.startswith("__")
-   and said.get(key) != value -%}
-{% set _ = said.update({key: value}) -%}
-{% set _ = labels.append(bullet(key, value)) -%}
+   if key not in shared
+   and key not in said_elsewhere
+   and not key.startswith("__") -%}
+{% set _ = shared.update({key: value}) -%}
 {% endfor -%}
 {% endfor -%}
 
-{# The dashboard and runbook links are buttons on the card, so they are not repeated as lines to copy out of.
-   `value_string` is the long form of `values`, dropped only when there is a `values` to read instead of it. -#}
+{% set summary = agreed.get("summary") -%}
+{% set description = agreed.get("description") -%}
+
+{# An instance says its own summary when its rule wrote one, because a sentence naming the thing reads better
+   than the labels the sentence was built from. Otherwise it names itself by the labels the group does not
+   share. Either way it is said once: not the summary already above, and not a line another instance has said. -#}
+{% set listed = [] -%}
+{% for instance in instances -%}
+{% set own = instance.get("annotations", {}).get("summary") -%}
+{% set apart = [] -%}
+{% for key, value in instance.get("labels", {}).items()
+   if key not in said_elsewhere
+   and not key.startswith("__")
+   and shared.get(key) != value -%}
+{% set _ = apart.append(pair(key, value) | trim) -%}
+{% endfor -%}
+{% if own -%}
+{% set line = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set line = apart | join(", ") -%}
+{% endif -%}
+{% if line and line != summary and line not in listed -%}
+{% set _ = listed.append(line) -%}
+{% endif -%}
+{% endfor -%}
+
+{# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
+   of `values`, dropped only when there is a `values` to read instead of it. -#}
 {% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
+{% set spoken = spoken + ["value_string"] if agreed.get("values") else spoken -%}
 {% set notes = [] -%}
-{% for key, value in annotations.items()
+{% for key, value in agreed.items()
    if key not in spoken
    and not key.startswith("__")
-   and said.get(key) != value -%}
-{% set _ = notes.append(bullet(key, value)) -%}
+   and shared.get(key) != value -%}
+{% set _ = notes.append(pair(key, value) | trim) -%}
 {% endfor -%}
 
-{% set summary = annotations.get("summary") -%}
-{% set description = annotations.get("description") -%}
 {% if summary -%}
 {{ summary }}
 {% endif -%}
@@ -259,64 +288,37 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
-{# One group can hold an instance per worker, region or host, and the route decides what they share: a label that
-   differs between them is in neither commonLabels nor commonAnnotations, and neither is a summary written from
-   it. Grouped by alertname alone, a card would name none of the things that are actually failing, so each
-   instance says itself — by its own summary, or by the labels that set it apart from the group. -#}
-{% set instances = [] -%}
-{% for alert in payload.get("alerts", []) -%}
-{% set own = alert.get("annotations", {}).get("summary") -%}
-{% set apart = [] -%}
-{% if not own -%}
-{% for key, value in alert.get("labels", {}).items()
-   if key not in ["alertname", "severity"]
-   and not key.startswith("__")
-   and commonLabels.get(key) != value -%}
-{% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
-{% endfor -%}
-{% endif -%}
-{% if own -%}
-{% set entry = (own | string).split() | join(" ") -%}
-{% else -%}
-{% set entry = apart | join(", ") -%}
-{% endif -%}
-{# Said once: not the summary the card has already printed above, and not another instance's line. -#}
-{% if entry and entry != summary and entry not in instances -%}
-{% set _ = instances.append(entry) -%}
-{% endif -%}
-{% endfor -%}
-
-{# A group of one says everything it has in the lines above. A group of many says what is in it, even when only
-   one of them turned out to carry anything of its own: that one line is the only thing naming what failed. -#}
-{% if instances and (payload.get("alerts", []) | length) > 1 %}
+{# A group of one has said everything it has above. A group of many says what is in it, even when only one of
+   them turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
+{% if listed and (instances | length) > 1 %}
 **Instances**
-{% for entry in instances[:20] -%}
-- {{ entry }}
+{% for line in listed[:20] -%}
+- {{ line }}
 {% endfor -%}
-{% if instances | length > 20 -%}
-- and {{ instances | length - 20 }} more
+{% if listed | length > 20 -%}
+- and {{ listed | length - 20 }} more
 {% endif -%}
 {% endif -%}
 
-{% if labels %}
+{% if shared %}
 **Labels**
-{% for entry in labels -%}
-{{ entry }}
+{% for key, value in shared.items() -%}
+- {{ pair(key, value) | trim }}
 {% endfor -%}
 {% endif -%}
 
 {% if notes %}
 **Annotations**
-{% for entry in notes -%}
-{{ entry }}
+{% for note in notes -%}
+- {{ note }}
 {% endfor -%}
 {% endif -%}
 
-{% if annotations.get("runbook_url") -%}
-[:book: Runbook]({{ annotations.runbook_url }})
+{% if agreed.get("runbook_url") -%}
+[:book: Runbook]({{ agreed.runbook_url }})
 {% endif -%}
-{% if annotations.get("runbook_url_internal") -%}
-[:closed_book: Runbook (internal)]({{ annotations.runbook_url_internal }})
+{% if agreed.get("runbook_url_internal") -%}
+[:closed_book: Runbook (internal)]({{ agreed.runbook_url_internal }})
 {% endif -%}
 """  # noqa
 

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -242,25 +242,35 @@ discord_message = """\
 {% set summary = agreed.get("summary") -%}
 {% set description = agreed.get("description") -%}
 
-{# An instance says its own summary when its rule wrote one, because a sentence naming the thing reads better
-   than the labels the sentence was built from. Otherwise it names itself by the labels the group does not
-   share. Either way it is said once: not the summary already above, and not a line another instance has said. -#}
+{# What identifies an instance is the labels the group does not share; a summary is prose that usually names
+   them and is not required to. So an instance says its own summary when its rule wrote one that is not already
+   the summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
+   every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
 {% set listed = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
+{% if own and own != summary -%}
+{% set prose = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set prose = "" -%}
+{% endif -%}
 {% set apart = [] -%}
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
-   and shared.get(key) != value -%}
+   and shared.get(key) != value
+   and (value | string) not in prose -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
-{% if own -%}
-{% set line = (own | string).split() | join(" ") -%}
+{% if prose and apart -%}
+{% set line = prose ~ " — " ~ (apart | join(", ")) -%}
+{% elif prose -%}
+{% set line = prose -%}
 {% else -%}
 {% set line = apart | join(", ") -%}
 {% endif -%}
-{% if line and line != summary and line not in listed -%}
+{# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
+{% if line and line not in listed -%}
 {% set _ = listed.append(line) -%}
 {% endif -%}
 {% endfor -%}

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -208,13 +208,13 @@ discord_title = web_title
 
 discord_message = """\
 {# A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels
-   and annotations. `groupLabels`, `commonLabels` and `commonAnnotations` are views Alertmanager derives from
-   them — the part the instances agree on. The legacy integration sends no `alerts` and puts a single instance's
-   labels and annotations at the top level, so it is read here as a group of one and nothing below this block has
-   to know which shape arrived.
+   and annotations. Everything else is a view Alertmanager derives from them — `groupLabels` is what the route
+   grouped by, `commonLabels` and `commonAnnotations` are what the instances happen to agree on. The legacy
+   integration sends no `alerts` and puts a single instance's labels and annotations at the top level, so it is
+   read here as a group of one and nothing after this block has to know which shape arrived.
 
-   A card says the agreed part once, and names the instances when there is more than one, because what sets them
-   apart is exactly what the agreed part cannot carry. -#}
+   A card says the agreed part once, and lists a summary per instance when it holds more than one, because what
+   sets the instances apart is exactly what the agreed part cannot carry. -#}
 {% macro pair(key, value) -%}
 {% set flat = (value | string).split() | join(" ") -%}
 {% if "`" in flat -%}
@@ -228,25 +228,26 @@ discord_message = """\
    Grafana wraps its own identifiers in double underscores and hides them in its own UI. -#}
 {% set said_elsewhere = ["alertname", "severity"] -%}
 {% set instances = payload.get("alerts") or [{"labels": payload.get("labels", {}), "annotations": payload.get("annotations", {})}] -%}
-{% set agreed = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
-{% set shared = {} -%}
-{% for source in [payload.get("groupLabels", {}), payload.get("commonLabels", {}), payload.get("labels", {})] -%}
+{% set grouped_by = payload.get("groupLabels", {}) -%}
+{% set annotations = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
+{% set agreed = {} -%}
+{% for source in [grouped_by, payload.get("commonLabels", {}), payload.get("labels", {})] -%}
 {% for key, value in source.items()
-   if key not in shared
+   if key not in agreed
    and key not in said_elsewhere
    and not key.startswith("__") -%}
-{% set _ = shared.update({key: value}) -%}
+{% set _ = agreed.update({key: value}) -%}
 {% endfor -%}
 {% endfor -%}
 
-{% set summary = agreed.get("summary") -%}
-{% set description = agreed.get("description") -%}
+{% set summary = annotations.get("summary") -%}
+{% set description = annotations.get("description") -%}
 
-{# What identifies an instance is the labels the group does not share; a summary is prose that usually names
-   them and is not required to. So an instance says its own summary when its rule wrote one that is not already
-   the summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
+{# What identifies an instance is the labels the group does not share; a summary is prose that usually names them
+   and is not required to. So an instance says its own summary when its rule wrote one that is not already the
+   summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
    every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
-{% set listed = [] -%}
+{% set summaries = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
 {% if own and own != summary -%}
@@ -258,7 +259,7 @@ discord_message = """\
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
-   and shared.get(key) != value
+   and agreed.get(key) != value
    and (value | string) not in prose -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
@@ -270,20 +271,20 @@ discord_message = """\
 {% set line = apart | join(", ") -%}
 {% endif -%}
 {# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
-{% if line and line not in listed -%}
-{% set _ = listed.append(line) -%}
+{% if line and line not in summaries -%}
+{% set _ = summaries.append(line) -%}
 {% endif -%}
 {% endfor -%}
 
 {# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
    of `values`, dropped only when there is a `values` to read instead of it. -#}
 {% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if agreed.get("values") else spoken -%}
+{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
 {% set notes = [] -%}
-{% for key, value in agreed.items()
+{% for key, value in annotations.items()
    if key not in spoken
    and not key.startswith("__")
-   and shared.get(key) != value -%}
+   and agreed.get(key) != value -%}
 {% set _ = notes.append(pair(key, value) | trim) -%}
 {% endfor -%}
 
@@ -298,21 +299,31 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
-{# A group of one has said everything it has above. A group of many says what is in it, even when only one of
-   them turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
-{% if listed and (instances | length) > 1 %}
-**Instances**
-{% for line in listed[:20] -%}
+{# A group of one has said its summary above. A group of many says one per instance, even when only one of them
+   turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
+{% if summaries and (instances | length) > 1 %}
+**Summaries**
+{% for line in summaries[:20] -%}
 - {{ line }}
 {% endfor -%}
-{% if listed | length > 20 -%}
-- and {{ listed | length - 20 }} more
+{% if summaries | length > 20 -%}
+- and {{ summaries | length - 20 }} more
 {% endif -%}
 {% endif -%}
 
-{% if shared %}
+{# What the route grouped by, and then what the instances turned out to share beyond it. Kept apart because they
+   answer different questions: the first is why these alerts arrived as one card, the second is what they have in
+   common once they had. -#}
+{% if agreed.keys() | select("in", grouped_by) | list %}
+**Group**
+{% for key, value in agreed.items() if key in grouped_by -%}
+- {{ pair(key, value) | trim }}
+{% endfor -%}
+{% endif -%}
+
+{% if agreed.keys() | reject("in", grouped_by) | list %}
 **Labels**
-{% for key, value in shared.items() -%}
+{% for key, value in agreed.items() if key not in grouped_by -%}
 - {{ pair(key, value) | trim }}
 {% endfor -%}
 {% endif -%}
@@ -324,11 +335,11 @@ discord_message = """\
 {% endfor -%}
 {% endif -%}
 
-{% if agreed.get("runbook_url") -%}
-[:book: Runbook]({{ agreed.runbook_url }})
+{% if annotations.get("runbook_url") -%}
+[:book: Runbook]({{ annotations.runbook_url }})
 {% endif -%}
-{% if agreed.get("runbook_url_internal") -%}
-[:closed_book: Runbook (internal)]({{ agreed.runbook_url_internal }})
+{% if annotations.get("runbook_url_internal") -%}
+[:closed_book: Runbook (internal)]({{ annotations.runbook_url_internal }})
 {% endif -%}
 """  # noqa
 

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -259,6 +259,40 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
+{# One group can hold an instance per worker, region or host, and the route decides what they share: a label that
+   differs between them is in neither commonLabels nor commonAnnotations, and neither is a summary written from
+   it. Grouped by alertname alone, a card would name none of the things that are actually failing, so each
+   instance says itself — by its own summary, or by the labels that set it apart from the group. -#}
+{% set instances = [] -%}
+{% for alert in payload.get("alerts", []) -%}
+{% set own = alert.get("annotations", {}).get("summary") -%}
+{% if own -%}
+{% set _ = instances.append((own | string).split() | join(" ")) -%}
+{% else -%}
+{% set apart = [] -%}
+{% for key, value in alert.get("labels", {}).items()
+   if key not in ["alertname", "severity"]
+   and not key.startswith("__")
+   and commonLabels.get(key) != value -%}
+{% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
+{% endfor -%}
+{% if apart -%}
+{% set _ = instances.append(apart | join(", ")) -%}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
+
+{# A group of one already says everything it has in the lines above. -#}
+{% if instances | length > 1 %}
+**Instances**
+{% for entry in instances[:20] -%}
+- {{ entry }}
+{% endfor -%}
+{% if instances | length > 20 -%}
+- and {{ instances | length - 20 }} more
+{% endif -%}
+{% endif -%}
+
 {% if labels %}
 **Labels**
 {% for entry in labels -%}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -268,24 +268,29 @@ discord_message = """\
 {% set instances = [] -%}
 {% for alert in payload.get("alerts", []) -%}
 {% set own = alert.get("annotations", {}).get("summary") -%}
-{% if own -%}
-{% set _ = instances.append((own | string).split() | join(" ")) -%}
-{% else -%}
 {% set apart = [] -%}
+{% if not own -%}
 {% for key, value in alert.get("labels", {}).items()
    if key not in ["alertname", "severity"]
    and not key.startswith("__")
    and commonLabels.get(key) != value -%}
 {% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
 {% endfor -%}
-{% if apart -%}
-{% set _ = instances.append(apart | join(", ")) -%}
 {% endif -%}
+{% if own -%}
+{% set entry = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set entry = apart | join(", ") -%}
+{% endif -%}
+{# Said once: not the summary the card has already printed above, and not another instance's line. -#}
+{% if entry and entry != summary and entry not in instances -%}
+{% set _ = instances.append(entry) -%}
 {% endif -%}
 {% endfor -%}
 
-{# A group of one already says everything it has in the lines above. -#}
-{% if instances | length > 1 %}
+{# A group of one says everything it has in the lines above. A group of many says what is in it, even when only
+   one of them turned out to carry anything of its own: that one line is the only thing naming what failed. -#}
+{% if instances and (payload.get("alerts", []) | length) > 1 %}
 **Instances**
 {% for entry in instances[:20] -%}
 - {{ entry }}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -244,25 +244,35 @@ discord_message = """\
 {% set summary = agreed.get("summary") -%}
 {% set description = agreed.get("description") -%}
 
-{# An instance says its own summary when its rule wrote one, because a sentence naming the thing reads better
-   than the labels the sentence was built from. Otherwise it names itself by the labels the group does not
-   share. Either way it is said once: not the summary already above, and not a line another instance has said. -#}
+{# What identifies an instance is the labels the group does not share; a summary is prose that usually names
+   them and is not required to. So an instance says its own summary when its rule wrote one that is not already
+   the summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
+   every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
 {% set listed = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
+{% if own and own != summary -%}
+{% set prose = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set prose = "" -%}
+{% endif -%}
 {% set apart = [] -%}
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
-   and shared.get(key) != value -%}
+   and shared.get(key) != value
+   and (value | string) not in prose -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
-{% if own -%}
-{% set line = (own | string).split() | join(" ") -%}
+{% if prose and apart -%}
+{% set line = prose ~ " — " ~ (apart | join(", ")) -%}
+{% elif prose -%}
+{% set line = prose -%}
 {% else -%}
 {% set line = apart | join(", ") -%}
 {% endif -%}
-{% if line and line != summary and line not in listed -%}
+{# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
+{% if line and line not in listed -%}
 {% set _ = listed.append(line) -%}
 {% endif -%}
 {% endfor -%}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -209,47 +209,76 @@ web_image_url = None
 discord_title = web_title
 
 discord_message = """\
-{% macro bullet(key, value) -%}
+{# A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels
+   and annotations. `groupLabels`, `commonLabels` and `commonAnnotations` are views Alertmanager derives from
+   them — the part the instances agree on. The legacy integration sends no `alerts` and puts a single instance's
+   labels and annotations at the top level, so it is read here as a group of one and nothing below this block has
+   to know which shape arrived.
+
+   A card says the agreed part once, and names the instances when there is more than one, because what sets them
+   apart is exactly what the agreed part cannot carry. -#}
+{% macro pair(key, value) -%}
 {% set flat = (value | string).split() | join(" ") -%}
 {% if "`" in flat -%}
-- {{ key }}: {{ flat }}
+{{ key }}: {{ flat }}
 {%- else -%}
-- {{ key }}: `{{ flat }}`
+{{ key }}: `{{ flat }}`
 {%- endif -%}
 {% endmacro -%}
-{% set groupLabels = payload.get("groupLabels", {}) -%}
-{% set commonLabels = payload.get("commonLabels", {}) -%}
-{# The legacy alertmanager integration puts labels and annotations at the top level instead. -#}
-{% set annotations = payload.get("commonAnnotations", {}) if payload.get("commonAnnotations") else payload.get("annotations", {}) -%}
-{% set legacyLabels = payload.get("labels", {}) -%}
 
-{# Grafana sends its own identifiers as labels too, wrapped in double underscores the same way. -#}
-{% set said = {} -%}
-{% set labels = [] -%}
-{% for source in [groupLabels, commonLabels, legacyLabels] -%}
+{# alertname titles the card, and severity is its title emoji and its forum tag, so neither is a line on it.
+   Grafana wraps its own identifiers in double underscores and hides them in its own UI. -#}
+{% set said_elsewhere = ["alertname", "severity"] -%}
+{% set instances = payload.get("alerts") or [{"labels": payload.get("labels", {}), "annotations": payload.get("annotations", {})}] -%}
+{% set agreed = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
+{% set shared = {} -%}
+{% for source in [payload.get("groupLabels", {}), payload.get("commonLabels", {}), payload.get("labels", {})] -%}
 {% for key, value in source.items()
-   if key not in ["alertname", "severity"]
-   and not key.startswith("__")
-   and said.get(key) != value -%}
-{% set _ = said.update({key: value}) -%}
-{% set _ = labels.append(bullet(key, value)) -%}
+   if key not in shared
+   and key not in said_elsewhere
+   and not key.startswith("__") -%}
+{% set _ = shared.update({key: value}) -%}
 {% endfor -%}
 {% endfor -%}
 
-{# The dashboard and runbook links are buttons on the card, so they are not repeated as lines to copy out of.
-   `value_string` is the long form of `values`, dropped only when there is a `values` to read instead of it. -#}
+{% set summary = agreed.get("summary") -%}
+{% set description = agreed.get("description") -%}
+
+{# An instance says its own summary when its rule wrote one, because a sentence naming the thing reads better
+   than the labels the sentence was built from. Otherwise it names itself by the labels the group does not
+   share. Either way it is said once: not the summary already above, and not a line another instance has said. -#}
+{% set listed = [] -%}
+{% for instance in instances -%}
+{% set own = instance.get("annotations", {}).get("summary") -%}
+{% set apart = [] -%}
+{% for key, value in instance.get("labels", {}).items()
+   if key not in said_elsewhere
+   and not key.startswith("__")
+   and shared.get(key) != value -%}
+{% set _ = apart.append(pair(key, value) | trim) -%}
+{% endfor -%}
+{% if own -%}
+{% set line = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set line = apart | join(", ") -%}
+{% endif -%}
+{% if line and line != summary and line not in listed -%}
+{% set _ = listed.append(line) -%}
+{% endif -%}
+{% endfor -%}
+
+{# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
+   of `values`, dropped only when there is a `values` to read instead of it. -#}
 {% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
+{% set spoken = spoken + ["value_string"] if agreed.get("values") else spoken -%}
 {% set notes = [] -%}
-{% for key, value in annotations.items()
+{% for key, value in agreed.items()
    if key not in spoken
    and not key.startswith("__")
-   and said.get(key) != value -%}
-{% set _ = notes.append(bullet(key, value)) -%}
+   and shared.get(key) != value -%}
+{% set _ = notes.append(pair(key, value) | trim) -%}
 {% endfor -%}
 
-{% set summary = annotations.get("summary") -%}
-{% set description = annotations.get("description") -%}
 {% if summary -%}
 {{ summary }}
 {% endif -%}
@@ -261,64 +290,37 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
-{# One group can hold an instance per worker, region or host, and the route decides what they share: a label that
-   differs between them is in neither commonLabels nor commonAnnotations, and neither is a summary written from
-   it. Grouped by alertname alone, a card would name none of the things that are actually failing, so each
-   instance says itself — by its own summary, or by the labels that set it apart from the group. -#}
-{% set instances = [] -%}
-{% for alert in payload.get("alerts", []) -%}
-{% set own = alert.get("annotations", {}).get("summary") -%}
-{% set apart = [] -%}
-{% if not own -%}
-{% for key, value in alert.get("labels", {}).items()
-   if key not in ["alertname", "severity"]
-   and not key.startswith("__")
-   and commonLabels.get(key) != value -%}
-{% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
-{% endfor -%}
-{% endif -%}
-{% if own -%}
-{% set entry = (own | string).split() | join(" ") -%}
-{% else -%}
-{% set entry = apart | join(", ") -%}
-{% endif -%}
-{# Said once: not the summary the card has already printed above, and not another instance's line. -#}
-{% if entry and entry != summary and entry not in instances -%}
-{% set _ = instances.append(entry) -%}
-{% endif -%}
-{% endfor -%}
-
-{# A group of one says everything it has in the lines above. A group of many says what is in it, even when only
-   one of them turned out to carry anything of its own: that one line is the only thing naming what failed. -#}
-{% if instances and (payload.get("alerts", []) | length) > 1 %}
+{# A group of one has said everything it has above. A group of many says what is in it, even when only one of
+   them turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
+{% if listed and (instances | length) > 1 %}
 **Instances**
-{% for entry in instances[:20] -%}
-- {{ entry }}
+{% for line in listed[:20] -%}
+- {{ line }}
 {% endfor -%}
-{% if instances | length > 20 -%}
-- and {{ instances | length - 20 }} more
+{% if listed | length > 20 -%}
+- and {{ listed | length - 20 }} more
 {% endif -%}
 {% endif -%}
 
-{% if labels %}
+{% if shared %}
 **Labels**
-{% for entry in labels -%}
-{{ entry }}
+{% for key, value in shared.items() -%}
+- {{ pair(key, value) | trim }}
 {% endfor -%}
 {% endif -%}
 
 {% if notes %}
 **Annotations**
-{% for entry in notes -%}
-{{ entry }}
+{% for note in notes -%}
+- {{ note }}
 {% endfor -%}
 {% endif -%}
 
-{% if annotations.get("runbook_url") -%}
-[:book: Runbook]({{ annotations.runbook_url }})
+{% if agreed.get("runbook_url") -%}
+[:book: Runbook]({{ agreed.runbook_url }})
 {% endif -%}
-{% if annotations.get("runbook_url_internal") -%}
-[:closed_book: Runbook (internal)]({{ annotations.runbook_url_internal }})
+{% if agreed.get("runbook_url_internal") -%}
+[:closed_book: Runbook (internal)]({{ agreed.runbook_url_internal }})
 {% endif -%}
 """  # noqa
 

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -210,13 +210,13 @@ discord_title = web_title
 
 discord_message = """\
 {# A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels
-   and annotations. `groupLabels`, `commonLabels` and `commonAnnotations` are views Alertmanager derives from
-   them — the part the instances agree on. The legacy integration sends no `alerts` and puts a single instance's
-   labels and annotations at the top level, so it is read here as a group of one and nothing below this block has
-   to know which shape arrived.
+   and annotations. Everything else is a view Alertmanager derives from them — `groupLabels` is what the route
+   grouped by, `commonLabels` and `commonAnnotations` are what the instances happen to agree on. The legacy
+   integration sends no `alerts` and puts a single instance's labels and annotations at the top level, so it is
+   read here as a group of one and nothing after this block has to know which shape arrived.
 
-   A card says the agreed part once, and names the instances when there is more than one, because what sets them
-   apart is exactly what the agreed part cannot carry. -#}
+   A card says the agreed part once, and lists a summary per instance when it holds more than one, because what
+   sets the instances apart is exactly what the agreed part cannot carry. -#}
 {% macro pair(key, value) -%}
 {% set flat = (value | string).split() | join(" ") -%}
 {% if "`" in flat -%}
@@ -230,25 +230,26 @@ discord_message = """\
    Grafana wraps its own identifiers in double underscores and hides them in its own UI. -#}
 {% set said_elsewhere = ["alertname", "severity"] -%}
 {% set instances = payload.get("alerts") or [{"labels": payload.get("labels", {}), "annotations": payload.get("annotations", {})}] -%}
-{% set agreed = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
-{% set shared = {} -%}
-{% for source in [payload.get("groupLabels", {}), payload.get("commonLabels", {}), payload.get("labels", {})] -%}
+{% set grouped_by = payload.get("groupLabels", {}) -%}
+{% set annotations = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
+{% set agreed = {} -%}
+{% for source in [grouped_by, payload.get("commonLabels", {}), payload.get("labels", {})] -%}
 {% for key, value in source.items()
-   if key not in shared
+   if key not in agreed
    and key not in said_elsewhere
    and not key.startswith("__") -%}
-{% set _ = shared.update({key: value}) -%}
+{% set _ = agreed.update({key: value}) -%}
 {% endfor -%}
 {% endfor -%}
 
-{% set summary = agreed.get("summary") -%}
-{% set description = agreed.get("description") -%}
+{% set summary = annotations.get("summary") -%}
+{% set description = annotations.get("description") -%}
 
-{# What identifies an instance is the labels the group does not share; a summary is prose that usually names
-   them and is not required to. So an instance says its own summary when its rule wrote one that is not already
-   the summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
+{# What identifies an instance is the labels the group does not share; a summary is prose that usually names them
+   and is not required to. So an instance says its own summary when its rule wrote one that is not already the
+   summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
    every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
-{% set listed = [] -%}
+{% set summaries = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
 {% if own and own != summary -%}
@@ -260,7 +261,7 @@ discord_message = """\
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
-   and shared.get(key) != value
+   and agreed.get(key) != value
    and (value | string) not in prose -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
@@ -272,20 +273,20 @@ discord_message = """\
 {% set line = apart | join(", ") -%}
 {% endif -%}
 {# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
-{% if line and line not in listed -%}
-{% set _ = listed.append(line) -%}
+{% if line and line not in summaries -%}
+{% set _ = summaries.append(line) -%}
 {% endif -%}
 {% endfor -%}
 
 {# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
    of `values`, dropped only when there is a `values` to read instead of it. -#}
 {% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if agreed.get("values") else spoken -%}
+{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
 {% set notes = [] -%}
-{% for key, value in agreed.items()
+{% for key, value in annotations.items()
    if key not in spoken
    and not key.startswith("__")
-   and shared.get(key) != value -%}
+   and agreed.get(key) != value -%}
 {% set _ = notes.append(pair(key, value) | trim) -%}
 {% endfor -%}
 
@@ -300,21 +301,31 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
-{# A group of one has said everything it has above. A group of many says what is in it, even when only one of
-   them turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
-{% if listed and (instances | length) > 1 %}
-**Instances**
-{% for line in listed[:20] -%}
+{# A group of one has said its summary above. A group of many says one per instance, even when only one of them
+   turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
+{% if summaries and (instances | length) > 1 %}
+**Summaries**
+{% for line in summaries[:20] -%}
 - {{ line }}
 {% endfor -%}
-{% if listed | length > 20 -%}
-- and {{ listed | length - 20 }} more
+{% if summaries | length > 20 -%}
+- and {{ summaries | length - 20 }} more
 {% endif -%}
 {% endif -%}
 
-{% if shared %}
+{# What the route grouped by, and then what the instances turned out to share beyond it. Kept apart because they
+   answer different questions: the first is why these alerts arrived as one card, the second is what they have in
+   common once they had. -#}
+{% if agreed.keys() | select("in", grouped_by) | list %}
+**Group**
+{% for key, value in agreed.items() if key in grouped_by -%}
+- {{ pair(key, value) | trim }}
+{% endfor -%}
+{% endif -%}
+
+{% if agreed.keys() | reject("in", grouped_by) | list %}
 **Labels**
-{% for key, value in shared.items() -%}
+{% for key, value in agreed.items() if key not in grouped_by -%}
 - {{ pair(key, value) | trim }}
 {% endfor -%}
 {% endif -%}
@@ -326,11 +337,11 @@ discord_message = """\
 {% endfor -%}
 {% endif -%}
 
-{% if agreed.get("runbook_url") -%}
-[:book: Runbook]({{ agreed.runbook_url }})
+{% if annotations.get("runbook_url") -%}
+[:book: Runbook]({{ annotations.runbook_url }})
 {% endif -%}
-{% if agreed.get("runbook_url_internal") -%}
-[:closed_book: Runbook (internal)]({{ agreed.runbook_url_internal }})
+{% if annotations.get("runbook_url_internal") -%}
+[:closed_book: Runbook (internal)]({{ annotations.runbook_url_internal }})
 {% endif -%}
 """  # noqa
 

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -261,6 +261,40 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
+{# One group can hold an instance per worker, region or host, and the route decides what they share: a label that
+   differs between them is in neither commonLabels nor commonAnnotations, and neither is a summary written from
+   it. Grouped by alertname alone, a card would name none of the things that are actually failing, so each
+   instance says itself — by its own summary, or by the labels that set it apart from the group. -#}
+{% set instances = [] -%}
+{% for alert in payload.get("alerts", []) -%}
+{% set own = alert.get("annotations", {}).get("summary") -%}
+{% if own -%}
+{% set _ = instances.append((own | string).split() | join(" ")) -%}
+{% else -%}
+{% set apart = [] -%}
+{% for key, value in alert.get("labels", {}).items()
+   if key not in ["alertname", "severity"]
+   and not key.startswith("__")
+   and commonLabels.get(key) != value -%}
+{% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
+{% endfor -%}
+{% if apart -%}
+{% set _ = instances.append(apart | join(", ")) -%}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
+
+{# A group of one already says everything it has in the lines above. -#}
+{% if instances | length > 1 %}
+**Instances**
+{% for entry in instances[:20] -%}
+- {{ entry }}
+{% endfor -%}
+{% if instances | length > 20 -%}
+- and {{ instances | length - 20 }} more
+{% endif -%}
+{% endif -%}
+
 {% if labels %}
 **Labels**
 {% for entry in labels -%}


### PR DESCRIPTION
## The problem

A `Queue has failed jobs` alert covering six regions arrived as a Discord card that named no queue and no cluster — just the description and a couple of shared labels.

It isn't the template picking badly. The default Grafana notification policy groups by `["grafana_folder", "alertname"]`:

```
$ gh api .../api/v1/provisioning/policies
{"group_by":["grafana_folder","alertname"], ...}
```

So every worker in every region collapses into **one** group. `service_name` differs between the instances, which keeps it out of `commonLabels`; each `summary` is written from `service_name`, which keeps every summary out of `commonAnnotations`. The card rendered `groupLabels` + `commonLabels` + `commonAnnotations`, and what those hold is exactly the part that identifies nothing.

## What the card renders

### 1. The alert that started this — four queues in one group

On `main`, no queue name and no cluster, because both differ between the instances:

```
This alert starts when the number of failed jobs in a queue grows over an hour. A job lands on the failed list when its worker throws and the broker gives up on it.

**Labels**
- grafana_folder: `Utopia`
- deployment_cluster_name: `cloud`
- team: `cloud`
```

Now. The default policy groups by `grafana_folder` and `alertname`, so `Group` says why these four arrived as one card and `Labels` holds the rest of what they share:

```
This alert starts when the number of failed jobs in a queue grows over an hour. A job lands on the failed list when its worker throws and the broker gives up on it.

**Summaries**
- The `builds` queue on `cloud-fra1-prod` has failed 2384 more jobs in the last hour.
- The `domains` queue on `cloud-syd1-prod` has failed 12825 more jobs in the last hour.
- The `databases` queue on `cloud-syd1-prod` has failed 7383 more jobs in the last hour.
- The `stats-edge` queue on `cloud-fra1-prod` has failed 3117 more jobs in the last hour.

**Group**
- grafana_folder: `Utopia`

**Labels**
- deployment_cluster_name: `cloud`
- team: `cloud`
```

### 2. A group of two where only one instance has anything of its own

The second instance's labels are all common to the group and its rule wrote no summary, so it contributes no line. Guarding on lines rather than alerts, this read as a group of one and threw the `builds` line away:

```
This alert starts when the number of failed jobs in a queue grows over an hour. A job lands on the failed list when its worker throws and the broker gives up on it.

**Labels**
- grafana_folder: `Utopia`
- team: `cloud`
- deployment_region_name: `fra`
```

Now:

```
This alert starts when the number of failed jobs in a queue grows over an hour. A job lands on the failed list when its worker throws and the broker gives up on it.

**Summaries**
- The `builds` queue on `cloud-fra1-prod` has failed 2384 more jobs in the last hour.

**Group**
- grafana_folder: `Utopia`

**Labels**
- team: `cloud`
- deployment_region_name: `fra`
```

### 3. Instances a shared sentence does not identify

Raised in review. A rule may write two instances the same sentence, and then it identifies neither of them. As this PR stood at review the pair collapsed into one entry naming no region and no node — two full disks reported as one:

```
A disk is above its watermark.

**Instances**
- Disk is nearly full.
- Root volume is nearly full.

**Labels**
- team: `cloud`
```

Now each line adds the labels its own sentence does not carry:

```
A disk is above its watermark.

**Summaries**
- Disk is nearly full. — region: `fra`, instance: `node-1`
- Disk is nearly full. — region: `syd`, instance: `node-2`
- Root volume is nearly full. — region: `tor`, instance: `node-3`

**Labels**
- team: `cloud`
```

### 4. …and the same defect when every alert was written that sentence

Identical across *all* of them puts it in `commonAnnotations`, so it was printed once at the top and then every line matched it and was dropped. The section vanished — three affected nodes, none named:

```
Disk is nearly full.

**Labels**
- team: `cloud`
```

Now the sentence stays at the top, said once, and the lines carry what tells them apart:

```
Disk is nearly full.

**Summaries**
- region: `fra`, instance: `node-1`
- region: `syd`, instance: `node-2`
- region: `tor`, instance: `node-3`

**Labels**
- team: `cloud`
```

### 5. A rule that does name the instance — nothing appended

Every label the sentence already carries is left off the line, so the common case stays one clean sentence. Section 1 is this case: `deployment_cluster_name` is under `Labels`, and no `service_name:` or `k8s_cluster_name:` is appended to any summary because each sentence already names both.

### 6. A group of one — its summary stays prose, with no Summaries list

```
The `builds` queue on `cloud-fra1-prod` has failed 12 more jobs in the last hour.

This alert starts when the number of failed jobs in a queue grows over an hour. A job lands on the failed list when its worker throws and the broker gives up on it.

**Group**
- service_name: `builds`

**Labels**
- k8s_cluster_name: `cloud-fra1-prod`
- team: `cloud`
```

### 7. Instances with no summary at all — named by what sets them apart

```
A certificate is inside its renewal window.

**Summaries**
- domain: `cloud.appwrite.io`
- domain: `api.appwrite.io`

**Group**
- region: `fra`

**Labels**
- team: `cloud`
```

### 8. Twenty-two instances — capped

```
This alert starts when the number of failed jobs in a queue grows over an hour. A job lands on the failed list when its worker throws and the broker gives up on it.

**Summaries**
- Shard 0 has failed 0 more jobs in the last hour.
- Shard 1 has failed 7 more jobs in the last hour.
- Shard 2 has failed 14 more jobs in the last hour.
- Shard 3 has failed 21 more jobs in the last hour.
- Shard 4 has failed 28 more jobs in the last hour.
- Shard 5 has failed 35 more jobs in the last hour.
- Shard 6 has failed 42 more jobs in the last hour.
- Shard 7 has failed 49 more jobs in the last hour.
- Shard 8 has failed 56 more jobs in the last hour.
- Shard 9 has failed 63 more jobs in the last hour.
- Shard 10 has failed 70 more jobs in the last hour.
- Shard 11 has failed 77 more jobs in the last hour.
- Shard 12 has failed 84 more jobs in the last hour.
- Shard 13 has failed 91 more jobs in the last hour.
- Shard 14 has failed 98 more jobs in the last hour.
- Shard 15 has failed 105 more jobs in the last hour.
- Shard 16 has failed 112 more jobs in the last hour.
- Shard 17 has failed 119 more jobs in the last hour.
- Shard 18 has failed 126 more jobs in the last hour.
- Shard 19 has failed 133 more jobs in the last hour.
- and 2 more

**Labels**
- team: `cloud`
```

### 9. Unchanged prose, and no Group heading when the payload has no groupLabels

A single-instance payload with Grafana's own `__…__` internals, a dashboard link and a runbook. The labels split across the two headings; the internals, the link and the title labels are still suppressed:

```
Synthetic test failed two consecutive runs.

**Group**
- name: `backups-tor`

**Labels**
- cluster: `assets-fra1-prod`
- grafana_folder: `Terraform Alerts`
- kind: `PlaywrightTest`
- service: `backups`
- team: `databases`

**Annotations**
- impact: `backups unverified`
[:book: Runbook](https://runbooks.example/synthetics)
```

The legacy top-level payload, read as a group of one. No `groupLabels`, so no `Group` heading, and the card reads as it does on `main`:

```
Instance has been down for more than 5 minutes.

**Labels**
- instance: `localhost:8082`
- job: `node`

**Annotations**
- impact: `one node`
```


## How it is built

The template had grown three notions of the same thing. Labels came from `groupLabels`, `commonLabels` and a legacy top-level `labels`, merged by a `said` dict that was also serving a second purpose: stopping annotations from repeating labels. Annotations came from `commonAnnotations` or a legacy top-level `annotations`, chosen inline. The instances block, added first in this PR, then re-derived the label filter and re-implemented the bullet formatting rather than use the macro ten lines above it.

A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels and annotations. Everything else is a view Alertmanager derives from them. The old template had that backwards — derived views as primary, ground truth as a bolt-on.

So the payload is read into that shape once, up front: the instances, what the route grouped by, and what the instances agree on, with the legacy shape normalised to a group of one. Nothing after that block knows which shape arrived. One formatter, `pair`, renders every key and value, so a summary line and a label line cannot drift apart. One predicate hides what the card says elsewhere.

Rules the card follows:

- **What identifies an instance is the labels the group does not share.** A summary is prose that usually names them and is not required to, so it cannot be the identity on its own (sections 3 and 4).
- An instance says its own summary when its rule wrote one that is not already the summary printed above, and then adds whichever of its own labels that sentence does not carry. A rule that does name the instance gets one clean sentence with nothing appended (sections 1 and 5).
- **A group holds a summary per instance, so the heading is plural and the lines are that list.** A group of one has said its summary as prose above and gets no list (section 6).
- Whether the list appears at all is decided by **how many alerts the group holds**, not how many of them had something to say — a group of many says what is in it even when only one instance carries anything (section 2).
- **`Group` and `Labels` answer different questions and get a heading each.** `groupLabels` is why these alerts arrived as one card; `commonLabels` is what they turned out to share once they had. A label belongs to one heading, not both. A payload with no `groupLabels` — the legacy shape among them — has no `Group` heading (section 9).
- Two instances that reduce to the same line are the same instance as far as a reader can tell, so that is said once. With identity on the line, distinct instances no longer reduce to the same line.
- Capped at 20 lines with an `and N more`, so a wide group stays readable on a phone (section 8).

Applied to both `grafana_alerting.py` and `alertmanager.py`, whose `discord_message` templates are byte-identical and stay so.

## Tests

Eight added to `engine/apps/discord/tests/test_alert_rendering.py`, following the existing payload-fixture style, each parametrized over both integrations where it applies:

- `test_a_card_names_each_instance_a_group_holds` — the live grouping: differing `service_name`, no summary in `commonAnnotations`.
- `test_a_card_lists_the_one_instance_of_a_group_that_says_anything` — section 2.
- `test_a_card_names_instances_a_shared_sentence_does_not` — section 3.
- `test_a_card_names_instances_when_every_summary_is_the_same` — section 4.
- `test_an_instance_line_does_not_repeat_what_its_summary_already_says` — section 5, the guard against over-appending.
- `test_a_card_does_not_list_the_one_instance_it_already_describes` — section 6.
- `test_a_card_keeps_what_the_route_grouped_by_apart_from_what_the_alerts_share` — the `Group` / `Labels` split, including that a label appears under one heading only.
- `test_a_card_says_an_instance_line_once` — a sentence said once, not per alert.

`make test-dev` fails on this repo for an unrelated reason: `settings/base.py` adds `apps.mattermost` behind a feature flag and `settings/ci_test.py` adds it again unconditionally, so `django.setup()` dies on `Application labels aren't unique`. Disabling the flag for the run avoids it without touching the settings:

```
COMPOSE_PROFILES=_engine_commands DB=sqlite BROKER_TYPE=redis SQLITE_DB_FILE="$PWD/engine/oncall.db" \
  docker compose -f docker-compose-developer.yml run --rm \
  -e FEATURE_MATTERMOST_INTEGRATION_ENABLED=false oncall_engine_commands \
  pytest --ds=settings.ci_test apps/discord apps/alerts/tests/test_alert_group_renderer.py apps/alerts/tests/test_default_templates.py
```

**196 passed** — 162 in `apps/discord` plus the two alert-rendering suites that read these configs. Every pre-existing test passes untouched. The four tests covering sections 3 and 4 were each confirmed failing against the template as it stood at review before the fix landed. Worth fixing that duplicate app label separately so CI can run at all.

One naming wart worth a look: a group whose alerts carry no summary at all gets label lines under a heading called `Summaries` (section 7). `Instances` covered that case more honestly but named the derivation rather than what a reader sees. Say the word if you would rather it switched heading when no line is prose.

Companion to appwrite-labs/monitoring#306, the alert whose card exposed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
