### PR TITLE
feat: post resolution notes beside the Discord card

### DIFF
--- a/docs/sources/manage/notify/discord/index.md
+++ b/docs/sources/manage/notify/discord/index.md
@@ -124,6 +124,10 @@ This is deliberately only the loud part. Reaching the right people is still the 
 their own notification policies, so that who gets woken respects who is actually on call. Nothing is posted if the
 alert group has already been acknowledged, silenced or resolved by the time the step runs.
 
+A resolution note created from the OnCall UI or the public API is posted the same way: beside the card, in the
+forum post or as a reply in a text channel. Mentions stay off. The alert group's `permalinks.discord` is a URL
+to that card.
+
 ## Split critical alerts from the rest
 
 A route also chooses how loud its alert groups read: **🚨 Critical**, **⚠️ Warning** or **📘 Info**. Set it to

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -568,17 +568,18 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
         if discord_message is None:
             return None
 
-        channel = DiscordChannel.objects.filter(
-            organization=self.channel.organization, channel_id=discord_message.channel_id
-        ).first()
-        if channel is None:
+        guild_id = discord_message.guild_id
+        if not guild_id:
+            channel = DiscordChannel.objects.filter(
+                organization=self.channel.organization, channel_id=discord_message.channel_id
+            ).first()
+            guild_id = channel.guild_id if channel else None
+        if not guild_id:
             return None
 
         if discord_message.thread_id:
-            return f"https://discord.com/channels/{channel.guild_id}/{discord_message.thread_id}"
-        return (
-            f"https://discord.com/channels/{channel.guild_id}/{discord_message.channel_id}/{discord_message.message_id}"
-        )
+            return f"https://discord.com/channels/{guild_id}/{discord_message.thread_id}"
+        return f"https://discord.com/channels/{guild_id}/{discord_message.channel_id}/{discord_message.message_id}"
 
     @property
     def permalinks(self) -> Permalinks:

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -100,6 +100,7 @@ class Permalinks(typing.TypedDict):
     slack: typing.Optional[str]
     slack_app: typing.Optional[str]
     telegram: typing.Optional[str]
+    discord: typing.Optional[str]
     web: str
 
 
@@ -545,11 +546,47 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
         return main_telegram_message.link if main_telegram_message else None
 
     @property
+    def discord_permalink(self) -> typing.Optional[str]:
+        """A Discord URL for the card, or None when Discord is off or the card was never posted.
+
+        A forum post is itself a channel, so the thread id is the destination. A card in a text
+        channel needs the message id as well, or the link opens the channel rather than the card.
+        """
+        if not settings.FEATURE_DISCORD_INTEGRATION_ENABLED:
+            return None
+
+        from apps.discord.models import DiscordChannel, DiscordMessage
+
+        try:
+            discord_message = self.prefetched_discord_messages[0] if self.prefetched_discord_messages else None
+        except AttributeError:
+            discord_message = (
+                self.discord_messages.filter(message_type=DiscordMessage.ALERT_GROUP_MESSAGE)
+                .order_by("created_at")
+                .first()
+            )
+        if discord_message is None:
+            return None
+
+        channel = DiscordChannel.objects.filter(
+            organization=self.channel.organization, channel_id=discord_message.channel_id
+        ).first()
+        if channel is None:
+            return None
+
+        if discord_message.thread_id:
+            return f"https://discord.com/channels/{channel.guild_id}/{discord_message.thread_id}"
+        return (
+            f"https://discord.com/channels/{channel.guild_id}/{discord_message.channel_id}/{discord_message.message_id}"
+        )
+
+    @property
     def permalinks(self) -> Permalinks:
         return {
             "slack": self.slack_permalink,
             "slack_app": self.slack_app_link,
             "telegram": self.telegram_permalink,
+            "discord": self.discord_permalink,
             "web": self.web_link,
         }
 

--- a/engine/apps/alerts/signals.py
+++ b/engine/apps/alerts/signals.py
@@ -21,7 +21,7 @@ alert_group_action_triggered_signal = django.dispatch.Signal()
 # when alert group state is changed
 alert_group_update_log_report_signal = django.dispatch.Signal()
 
-# Signal to rerender alert group's resolution note in all connected integrations (Slack)
+# Signal to rerender alert group's resolution note in all connected integrations (Slack, Discord)
 alert_group_update_resolution_note_signal = django.dispatch.Signal()
 
 # Signal to post acknowledge reminder message (Slack)

--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import typing
 
+from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Prefetch
 from django.utils import timezone
@@ -149,6 +150,18 @@ class AlertGroupListSerializer(
             to_attr="prefetched_telegram_messages",
         ),
     ]
+    if settings.FEATURE_DISCORD_INTEGRATION_ENABLED:
+        from apps.discord.models import DiscordMessage
+
+        PREFETCH_RELATED = PREFETCH_RELATED + [
+            Prefetch(
+                "discord_messages",
+                queryset=DiscordMessage.objects.filter(message_type=DiscordMessage.ALERT_GROUP_MESSAGE).order_by(
+                    "created_at"
+                )[:1],
+                to_attr="prefetched_discord_messages",
+            ),
+        ]
 
     SELECT_RELATED = [
         "channel__organization",

--- a/engine/apps/discord/alert_group_representative.py
+++ b/engine/apps/discord/alert_group_representative.py
@@ -4,10 +4,14 @@ from rest_framework import status
 
 from apps.alerts.models import AlertGroup
 from apps.alerts.representative import AlertGroupAbstractRepresentative
-from apps.discord.alert_rendering import DiscordMessageRenderer
+from apps.discord.alert_rendering import DiscordMessageRenderer, render_resolution_note
 from apps.discord.client import DiscordClient
 from apps.discord.exceptions import DiscordAPIException, DiscordAPITokenInvalid
-from apps.discord.tasks import on_alert_group_action_triggered_async, on_create_alert_async
+from apps.discord.tasks import (
+    on_alert_group_action_triggered_async,
+    on_create_alert_async,
+    on_resolution_note_async,
+)
 from apps.discord.utils import beside_card
 
 logger = logging.getLogger(__name__)
@@ -131,6 +135,49 @@ class AlertGroupDiscordRepresentative(AlertGroupAbstractRepresentative):
             if ex.status not in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]:
                 raise ex
 
+    @classmethod
+    def post_resolution_note(cls, alert_group: AlertGroup, resolution_note):
+        """Post a resolution note beside the card, the same place escalation pings land.
+
+        A quiet forum post is archived by Discord and will not accept a message, so the
+        post is unarchived first. Mentions stay off: the note is whoever wrote it, not
+        a page.
+        """
+        from apps.discord.models import DiscordMessage
+
+        if resolution_note is None or resolution_note.deleted_at:
+            return
+
+        discord_message = (
+            alert_group.discord_messages.filter(message_type=DiscordMessage.ALERT_GROUP_MESSAGE)
+            .order_by("created_at")
+            .first()
+        )
+        if discord_message is None:
+            return
+
+        payload = render_resolution_note(resolution_note)
+        channel_id, reference = beside_card(discord_message)
+        payload.update(reference)
+
+        try:
+            client = DiscordClient()
+            if discord_message.thread_id:
+                client.update_thread(thread_id=discord_message.thread_id, archived=False)
+            client.create_message(
+                channel_id=channel_id,
+                data=payload,
+                nonce=f"rn-{resolution_note.pk}",
+            )
+        except DiscordAPITokenInvalid:
+            logger.error(
+                f"Discord bot token is invalid, could not post resolution note for alert group {alert_group.pk}"
+            )
+        except DiscordAPIException as ex:
+            logger.error(f"Discord API error {ex}")
+            if ex.status not in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND]:
+                raise ex
+
     @staticmethod
     def on_create_alert(**kwargs):
         on_create_alert_async.apply_async((kwargs["alert"],))
@@ -142,6 +189,13 @@ class AlertGroupDiscordRepresentative(AlertGroupAbstractRepresentative):
         log_record = kwargs["log_record"]
         log_record_id = log_record.pk if isinstance(log_record, AlertGroupLogRecord) else log_record
         on_alert_group_action_triggered_async.apply_async((log_record_id,))
+
+    @staticmethod
+    def on_alert_group_update_resolution_note(**kwargs):
+        resolution_note = kwargs.get("resolution_note")
+        if resolution_note is None:
+            return
+        on_resolution_note_async.apply_async((resolution_note.pk,))
 
     def get_handler(self):
         handler_name = self.get_handler_name()

--- a/engine/apps/discord/alert_group_representative.py
+++ b/engine/apps/discord/alert_group_representative.py
@@ -7,11 +7,7 @@ from apps.alerts.representative import AlertGroupAbstractRepresentative
 from apps.discord.alert_rendering import DiscordMessageRenderer, render_resolution_note
 from apps.discord.client import DiscordClient
 from apps.discord.exceptions import DiscordAPIException, DiscordAPITokenInvalid
-from apps.discord.tasks import (
-    on_alert_group_action_triggered_async,
-    on_create_alert_async,
-    on_resolution_note_async,
-)
+from apps.discord.tasks import on_alert_group_action_triggered_async, on_create_alert_async, on_resolution_note_async
 from apps.discord.utils import beside_card
 
 logger = logging.getLogger(__name__)
@@ -137,41 +133,77 @@ class AlertGroupDiscordRepresentative(AlertGroupAbstractRepresentative):
 
     @classmethod
     def post_resolution_note(cls, alert_group: AlertGroup, resolution_note):
-        """Post a resolution note beside the card, the same place escalation pings land.
+        """Create, update, or delete the Discord message synchronized with a resolution note."""
+        from apps.discord.models import DiscordMessage, DiscordResolutionNoteMessage
 
-        A quiet forum post is archived by Discord and will not accept a message, so the
-        post is unarchived first. Mentions stay off: the note is whoever wrote it, not
-        a page.
-        """
-        from apps.discord.models import DiscordMessage
-
-        if resolution_note is None or resolution_note.deleted_at:
+        if resolution_note is None:
             return
 
-        discord_message = (
-            alert_group.discord_messages.filter(message_type=DiscordMessage.ALERT_GROUP_MESSAGE)
-            .order_by("created_at")
-            .first()
-        )
-        if discord_message is None:
+        note_message = DiscordResolutionNoteMessage.objects.filter(resolution_note_id=resolution_note.pk).first()
+        if resolution_note.deleted_at:
+            if note_message is None:
+                return
+            try:
+                client = DiscordClient()
+                if note_message.thread_id:
+                    client.update_thread(thread_id=note_message.thread_id, archived=False)
+                client.delete_message(channel_id=note_message.channel_id, message_id=note_message.message_id)
+            except DiscordAPITokenInvalid:
+                logger.error(
+                    f"Discord bot token is invalid, could not delete resolution note for alert group {alert_group.pk}"
+                )
+                return
+            except DiscordAPIException as ex:
+                logger.error(f"Discord API error {ex}")
+                if ex.status != status.HTTP_404_NOT_FOUND:
+                    if ex.status not in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]:
+                        raise ex
+                    return
+            note_message.delete()
             return
+
+        discord_message = None
+        if note_message is None:
+            discord_message = (
+                alert_group.discord_messages.filter(message_type=DiscordMessage.ALERT_GROUP_MESSAGE)
+                .order_by("created_at")
+                .first()
+            )
+            if discord_message is None:
+                return
 
         payload = render_resolution_note(resolution_note)
-        channel_id, reference = beside_card(discord_message)
-        payload.update(reference)
 
         try:
             client = DiscordClient()
-            if discord_message.thread_id:
-                client.update_thread(thread_id=discord_message.thread_id, archived=False)
-            client.create_message(
-                channel_id=channel_id,
-                data=payload,
-                nonce=f"rn-{resolution_note.pk}",
-            )
+            thread_id = note_message.thread_id if note_message else discord_message.thread_id
+            if thread_id:
+                client.update_thread(thread_id=thread_id, archived=False)
+            if note_message:
+                client.update_message(
+                    channel_id=note_message.channel_id,
+                    message_id=note_message.message_id,
+                    data=payload,
+                )
+            else:
+                channel_id, reference = beside_card(discord_message)
+                payload.update(reference)
+                posted = client.create_message(
+                    channel_id=channel_id,
+                    data=payload,
+                    nonce=f"rn-{resolution_note.pk}",
+                )
+                DiscordResolutionNoteMessage.objects.update_or_create(
+                    resolution_note=resolution_note,
+                    defaults={
+                        "channel_id": posted.channel_id,
+                        "message_id": posted.message_id,
+                        "thread_id": discord_message.thread_id,
+                    },
+                )
         except DiscordAPITokenInvalid:
             logger.error(
-                f"Discord bot token is invalid, could not post resolution note for alert group {alert_group.pk}"
+                f"Discord bot token is invalid, could not synchronize resolution note for alert group {alert_group.pk}"
             )
         except DiscordAPIException as ex:
             logger.error(f"Discord API error {ex}")

--- a/engine/apps/discord/alert_group_representative.py
+++ b/engine/apps/discord/alert_group_representative.py
@@ -152,13 +152,11 @@ class AlertGroupDiscordRepresentative(AlertGroupAbstractRepresentative):
                 logger.error(
                     f"Discord bot token is invalid, could not delete resolution note for alert group {alert_group.pk}"
                 )
-                return
+                raise
             except DiscordAPIException as ex:
                 logger.error(f"Discord API error {ex}")
                 if ex.status != status.HTTP_404_NOT_FOUND:
-                    if ex.status not in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]:
-                        raise ex
-                    return
+                    raise ex
             note_message.delete()
             return
 

--- a/engine/apps/discord/alert_rendering.py
+++ b/engine/apps/discord/alert_rendering.py
@@ -6,7 +6,7 @@ from emoji import emojize
 
 from apps.alerts.incident_appearance.renderers.base_renderer import AlertBaseRenderer, AlertGroupBaseRenderer
 from apps.alerts.incident_appearance.templaters.alert_templater import AlertTemplater
-from apps.alerts.models import Alert, AlertGroup
+from apps.alerts.models import Alert, AlertGroup, ResolutionNote
 from apps.discord.client import THREAD_NAME_LIMIT
 from common.utils import is_string_with_visible_characters, str_or_backup
 
@@ -93,6 +93,26 @@ def stamp(moment) -> str:
     """A moment as Discord renders it: the reader's own clock, and how long ago in their own words."""
     seconds = int(moment.timestamp())
     return f"<t:{seconds}:t> (<t:{seconds}:R>)"
+
+
+def render_resolution_note(resolution_note: ResolutionNote) -> dict:
+    """A resolution note as a follow-up beside the card.
+
+    The note is already capped at 3000 characters in OnCall, which fits an embed
+    description. Mentions are never resolved: the text is attacker-adjacent the
+    same way an alert annotation is.
+    """
+    author = resolution_note.author.username if resolution_note.author else "OnCall"
+    return {
+        "embeds": [
+            {
+                "title": "Investigation",
+                "description": truncate(resolution_note.text or "", EMBED_DESCRIPTION_LIMIT),
+                "footer": {"text": truncate(f"Note from {author}", EMBED_FOOTER_LIMIT)},
+            }
+        ],
+        "allowed_mentions": {"parse": []},
+    }
 
 
 def route_config(alert_group: AlertGroup) -> dict:

--- a/engine/apps/discord/client.py
+++ b/engine/apps/discord/client.py
@@ -86,7 +86,7 @@ class DiscordClient:
             )
         except requests.RequestException as ex:
             raise DiscordAPIException(status=None, url=url, msg=str(ex), method=method)
-        return response.json()
+        return response.json() if response.content else None
 
     def get_channel(self, channel_id: str) -> DiscordChannel:
         data = self._request("GET", f"{self.base_url}/channels/{channel_id}")
@@ -175,6 +175,9 @@ class DiscordClient:
     def update_message(self, channel_id: str, message_id: str, data: dict) -> DiscordMessage:
         response = self._request("PATCH", f"{self.base_url}/channels/{channel_id}/messages/{message_id}", data=data)
         return DiscordMessage(message_id=response["id"], channel_id=response["channel_id"])
+
+    def delete_message(self, channel_id: str, message_id: str) -> None:
+        self._request("DELETE", f"{self.base_url}/channels/{channel_id}/messages/{message_id}")
 
 
 def _acts_on(message: dict, marker: str) -> bool:

--- a/engine/apps/discord/migrations/0003_discordmessage_guild_id_and_resolution_note_message.py
+++ b/engine/apps/discord/migrations/0003_discordmessage_guild_id_and_resolution_note_message.py
@@ -1,0 +1,53 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def backfill_guild_ids(apps, schema_editor):
+    DiscordChannel = apps.get_model("discord", "DiscordChannel")
+    DiscordMessage = apps.get_model("discord", "DiscordMessage")
+
+    messages = DiscordMessage.objects.filter(guild_id__isnull=True).select_related("alert_group__channel")
+    for message in messages.iterator():
+        channel = DiscordChannel.objects.filter(
+            organization_id=message.alert_group.channel.organization_id,
+            channel_id=message.channel_id,
+        ).first()
+        if channel:
+            DiscordMessage.objects.filter(pk=message.pk).update(guild_id=channel.guild_id)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("alerts", "0077_alter_resolutionnote_source"),
+        ("discord", "0002_discordchannel_available_tags_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="discordmessage",
+            name="guild_id",
+            field=models.CharField(default=None, max_length=100, null=True),
+        ),
+        migrations.RunPython(backfill_guild_ids, migrations.RunPython.noop),
+        migrations.CreateModel(
+            name="DiscordResolutionNoteMessage",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("message_id", models.CharField(max_length=100)),
+                ("channel_id", models.CharField(max_length=100)),
+                ("thread_id", models.CharField(default=None, max_length=100, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "resolution_note",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="discord_message",
+                        to="alerts.resolutionnote",
+                    ),
+                ),
+            ],
+            options={
+                "indexes": [models.Index(fields=["channel_id", "message_id"], name="discord_dis_channel_8e256c_idx")],
+            },
+        ),
+    ]

--- a/engine/apps/discord/migrations/0003_discordmessage_guild_id_and_resolution_note_message.py
+++ b/engine/apps/discord/migrations/0003_discordmessage_guild_id_and_resolution_note_message.py
@@ -47,7 +47,7 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "indexes": [models.Index(fields=["channel_id", "message_id"], name="discord_dis_channel_8e256c_idx")],
+                "indexes": [models.Index(fields=["channel_id", "message_id"], name="discord_dis_channel_51254e_idx")],
             },
         ),
     ]

--- a/engine/apps/discord/models/__init__.py
+++ b/engine/apps/discord/models/__init__.py
@@ -1,3 +1,3 @@
 from .channel import DiscordChannel  # noqa: F401
-from .message import DiscordMessage  # noqa: F401
+from .message import DiscordMessage, DiscordResolutionNoteMessage  # noqa: F401
 from .user import DiscordUser  # noqa: F401

--- a/engine/apps/discord/models/message.py
+++ b/engine/apps/discord/models/message.py
@@ -21,6 +21,9 @@ class DiscordMessage(models.Model):
 
     channel_id = models.CharField(max_length=100)
 
+    # Kept with the placement so links survive disconnecting (and deleting) the configured channel.
+    guild_id = models.CharField(max_length=100, null=True, default=None)
+
     # Set when the alert group lives in a forum post rather than a channel message. A thread and its first message
     # share an id, so this is both the post and the message to edit inside it.
     thread_id = models.CharField(max_length=100, null=True, default=None)
@@ -53,6 +56,7 @@ class DiscordMessage(models.Model):
         message: DiscordAPIMessage,
         message_type: int,
         thread_id: typing.Optional[str] = None,
+        guild_id: typing.Optional[str] = None,
     ) -> "DiscordMessage":
         """Record where a message landed, idempotently.
 
@@ -60,10 +64,30 @@ class DiscordMessage(models.Model):
         post with the same message. Matching the uniqueness constraint here means that retry settles on the row it
         meant to write instead of raising against it.
         """
-        discord_message, _ = DiscordMessage.objects.get_or_create(
+        discord_message, created = DiscordMessage.objects.get_or_create(
             alert_group=alert_group,
             message_type=message_type,
             channel_id=message.channel_id,
-            defaults={"message_id": message.message_id, "thread_id": thread_id},
+            defaults={"message_id": message.message_id, "thread_id": thread_id, "guild_id": guild_id},
         )
+        if not created and guild_id and not discord_message.guild_id:
+            discord_message.guild_id = guild_id
+            discord_message.save(update_fields=["guild_id"])
         return discord_message
+
+
+class DiscordResolutionNoteMessage(models.Model):
+    """The Discord message synchronized with one resolution note."""
+
+    resolution_note = models.OneToOneField(
+        "alerts.ResolutionNote",
+        on_delete=models.CASCADE,
+        related_name="discord_message",
+    )
+    message_id = models.CharField(max_length=100)
+    channel_id = models.CharField(max_length=100)
+    thread_id = models.CharField(max_length=100, null=True, default=None)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        indexes = [models.Index(fields=["channel_id", "message_id"])]

--- a/engine/apps/discord/signals.py
+++ b/engine/apps/discord/signals.py
@@ -1,5 +1,10 @@
-from apps.alerts.signals import alert_create_signal, alert_group_action_triggered_signal
+from apps.alerts.signals import (
+    alert_create_signal,
+    alert_group_action_triggered_signal,
+    alert_group_update_resolution_note_signal,
+)
 from apps.discord.alert_group_representative import AlertGroupDiscordRepresentative
 
 alert_create_signal.connect(AlertGroupDiscordRepresentative.on_create_alert)
 alert_group_action_triggered_signal.connect(AlertGroupDiscordRepresentative.on_alert_group_action_triggered)
+alert_group_update_resolution_note_signal.connect(AlertGroupDiscordRepresentative.on_alert_group_update_resolution_note)

--- a/engine/apps/discord/tasks.py
+++ b/engine/apps/discord/tasks.py
@@ -9,7 +9,7 @@ from apps.discord.alert_rendering import AlertGroupDiscordRenderer, DiscordMessa
 from apps.discord.client import DiscordClient
 from apps.discord.client import DiscordMessage as DiscordAPIMessage
 from apps.discord.exceptions import DiscordAPIException, DiscordAPITokenInvalid
-from apps.discord.models import DiscordChannel, DiscordMessage
+from apps.discord.models import DiscordChannel, DiscordMessage, DiscordResolutionNoteMessage
 from apps.discord.utils import beside_card
 from apps.user_management.models import User
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
@@ -119,6 +119,7 @@ def on_create_alert_async(self, alert_pk):
                     message=discord_message,
                     message_type=DiscordMessage.ALERT_GROUP_MESSAGE,
                     thread_id=thread_id,
+                    guild_id=discord_channel.guild_id,
                 )
 
 
@@ -157,33 +158,28 @@ def on_alert_group_action_triggered_async(log_record_id):
     autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
 )
 def on_resolution_note_async(resolution_note_pk):
-    """Post a resolution note beside the Discord card once that card exists.
-
-    The card is written by another task, so a note that arrives first has to wait.
-    A deleted note is a no-op: we do not store the Discord message id, so there is
-    nothing to take down.
-    """
+    """Synchronize a resolution note beside the Discord card once that card exists."""
     from apps.alerts.models import ResolutionNote
     from apps.discord.alert_group_representative import AlertGroupDiscordRepresentative
 
     try:
         resolution_note = ResolutionNote.objects_with_deleted.get(pk=resolution_note_pk)
     except ResolutionNote.DoesNotExist as e:
-        logger.warning(f"Discord representative: resolution note {resolution_note_pk} never created or has been deleted")
+        logger.warning(
+            f"Discord representative: resolution note {resolution_note_pk} never created or has been deleted"
+        )
         raise e
 
     alert_group = resolution_note.alert_group
-    if resolution_note.deleted_at:
-        logger.info(f"Resolution note {resolution_note_pk} was deleted, not posting it to discord")
-        return
-
-    try:
-        alert_group.discord_messages.get(message_type=DiscordMessage.ALERT_GROUP_MESSAGE)
-    except DiscordMessage.DoesNotExist as e:
-        if on_resolution_note_async.request.retries >= 10:
-            logger.error(f"Discord message not created for {alert_group.pk}. Stop retrying resolution note")
-            return
-        raise e
+    note_was_posted = DiscordResolutionNoteMessage.objects.filter(resolution_note_id=resolution_note_pk).exists()
+    if not resolution_note.deleted_at and not note_was_posted:
+        try:
+            alert_group.discord_messages.get(message_type=DiscordMessage.ALERT_GROUP_MESSAGE)
+        except DiscordMessage.DoesNotExist as e:
+            if on_resolution_note_async.request.retries >= 10:
+                logger.error(f"Discord message not created for {alert_group.pk}. Stop retrying resolution note")
+                return
+            raise e
 
     logger.info(f"Start discord on_resolution_note for alert_group {alert_group.pk}, note {resolution_note_pk}")
     AlertGroupDiscordRepresentative.post_resolution_note(alert_group, resolution_note)

--- a/engine/apps/discord/tasks.py
+++ b/engine/apps/discord/tasks.py
@@ -156,6 +156,42 @@ def on_alert_group_action_triggered_async(log_record_id):
 @shared_dedicated_queue_retry_task(
     autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
 )
+def on_resolution_note_async(resolution_note_pk):
+    """Post a resolution note beside the Discord card once that card exists.
+
+    The card is written by another task, so a note that arrives first has to wait.
+    A deleted note is a no-op: we do not store the Discord message id, so there is
+    nothing to take down.
+    """
+    from apps.alerts.models import ResolutionNote
+    from apps.discord.alert_group_representative import AlertGroupDiscordRepresentative
+
+    try:
+        resolution_note = ResolutionNote.objects_with_deleted.get(pk=resolution_note_pk)
+    except ResolutionNote.DoesNotExist as e:
+        logger.warning(f"Discord representative: resolution note {resolution_note_pk} never created or has been deleted")
+        raise e
+
+    alert_group = resolution_note.alert_group
+    if resolution_note.deleted_at:
+        logger.info(f"Resolution note {resolution_note_pk} was deleted, not posting it to discord")
+        return
+
+    try:
+        alert_group.discord_messages.get(message_type=DiscordMessage.ALERT_GROUP_MESSAGE)
+    except DiscordMessage.DoesNotExist as e:
+        if on_resolution_note_async.request.retries >= 10:
+            logger.error(f"Discord message not created for {alert_group.pk}. Stop retrying resolution note")
+            return
+        raise e
+
+    logger.info(f"Start discord on_resolution_note for alert_group {alert_group.pk}, note {resolution_note_pk}")
+    AlertGroupDiscordRepresentative.post_resolution_note(alert_group, resolution_note)
+
+
+@shared_dedicated_queue_retry_task(
+    autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
+)
 def notify_user_about_alert_async(user_pk, alert_group_pk, notification_policy_pk):
     from apps.base.models import UserNotificationPolicy, UserNotificationPolicyLogRecord
 

--- a/engine/apps/discord/tasks.py
+++ b/engine/apps/discord/tasks.py
@@ -159,6 +159,17 @@ def on_alert_group_action_triggered_async(log_record_id):
 )
 def on_resolution_note_async(resolution_note_pk):
     """Synchronize a resolution note beside the Discord card once that card exists."""
+    lock_id = f"discord-resolution-note-{resolution_note_pk}"
+    lock_owner = on_resolution_note_async.request.id or f"resolution-note-{resolution_note_pk}"
+    with task_lock(lock_id, lock_owner) as acquired:
+        if not acquired:
+            # Do not drop a concurrent edit or delete. Raising lets Celery retry after the task holding the lock
+            # has recorded its placement, and the retry reads the note's latest state from the database.
+            raise RuntimeError(f"Another task is synchronizing resolution note {resolution_note_pk}")
+        _synchronize_resolution_note(resolution_note_pk)
+
+
+def _synchronize_resolution_note(resolution_note_pk):
     from apps.alerts.models import ResolutionNote
     from apps.discord.alert_group_representative import AlertGroupDiscordRepresentative
 

--- a/engine/apps/discord/tests/test_client.py
+++ b/engine/apps/discord/tests/test_client.py
@@ -41,6 +41,16 @@ def test_update_message():
 
 @pytest.mark.django_db
 @responses.activate
+def test_delete_message():
+    responses.add(responses.DELETE, f"{DISCORD_API_URL}/channels/123/messages/456", status=204)
+
+    DiscordClient().delete_message(channel_id="123", message_id="456")
+
+    assert len(responses.calls) == 1
+
+
+@pytest.mark.django_db
+@responses.activate
 def test_get_channel():
     responses.add(
         responses.GET,

--- a/engine/apps/discord/tests/test_resolution_note.py
+++ b/engine/apps/discord/tests/test_resolution_note.py
@@ -223,6 +223,20 @@ def test_the_task_retries_until_the_card_exists(
 
 
 @pytest.mark.django_db
+def test_the_task_retries_when_another_note_sync_holds_the_lock(posted_note):
+    _, note, _, _ = posted_note()
+
+    with patch("apps.discord.tasks.task_lock") as lock, patch(
+        "apps.discord.alert_group_representative.AlertGroupDiscordRepresentative.post_resolution_note"
+    ) as post_resolution_note:
+        lock.return_value.__enter__.return_value = False
+        with pytest.raises(RuntimeError):
+            on_resolution_note_async(note.pk)
+
+    post_resolution_note.assert_not_called()
+
+
+@pytest.mark.django_db
 def test_the_signal_queues_the_note_task(posted_note):
     _, note, _, _ = posted_note()
 

--- a/engine/apps/discord/tests/test_resolution_note.py
+++ b/engine/apps/discord/tests/test_resolution_note.py
@@ -192,6 +192,25 @@ def test_a_deleted_note_removes_the_existing_message(posted_note, thread_id, mis
 
 
 @pytest.mark.django_db
+def test_a_failed_note_deletion_is_retried(posted_note):
+    alert_group, note, message, _ = posted_note()
+    note_message = DiscordResolutionNoteMessage.objects.create(
+        resolution_note=note,
+        channel_id=message.channel_id,
+        message_id="1300000000000000010",
+    )
+    note.delete()
+    note = ResolutionNote.objects_with_deleted.get(pk=note.pk)
+    error = DiscordAPIException(status=403, url="unused", method="DELETE")
+
+    with patch("apps.discord.alert_group_representative.DiscordClient.delete_message", side_effect=error):
+        with pytest.raises(DiscordAPIException):
+            AlertGroupDiscordRepresentative.post_resolution_note(alert_group, note)
+
+    assert DiscordResolutionNoteMessage.objects.filter(pk=note_message.pk).exists()
+
+
+@pytest.mark.django_db
 def test_a_deleted_note_is_not_posted(posted_note):
     alert_group, note, _, _ = posted_note(deleted=True)
 

--- a/engine/apps/discord/tests/test_resolution_note.py
+++ b/engine/apps/discord/tests/test_resolution_note.py
@@ -1,0 +1,160 @@
+"""A resolution note lands beside the Discord card, the same place escalation pings go."""
+
+from unittest.mock import patch
+
+import pytest
+
+from apps.alerts.models import AlertReceiveChannel, ResolutionNote
+from apps.discord.alert_group_representative import AlertGroupDiscordRepresentative
+from apps.discord.models import DiscordMessage
+from apps.discord.tasks import on_resolution_note_async
+
+
+@pytest.fixture()
+def posted_note(
+    make_organization,
+    make_user_for_organization,
+    make_discord_channel,
+    make_alert_receive_channel,
+    make_alert_group,
+    make_alert,
+    make_discord_message,
+    make_resolution_note,
+):
+    def _posted_note(thread_id=None, deleted=False, **channel_kwargs):
+        organization = make_organization()
+        user = make_user_for_organization(organization, username="investigator")
+        channel = make_discord_channel(
+            organization=organization, is_default_channel=True, guild_id="1300000000000000100", **channel_kwargs
+        )
+        alert_receive_channel = make_alert_receive_channel(
+            organization, integration=AlertReceiveChannel.INTEGRATION_GRAFANA
+        )
+        alert_group = make_alert_group(alert_receive_channel=alert_receive_channel)
+        make_alert(alert_group=alert_group, raw_request_data=alert_receive_channel.config.example_payload)
+        message = make_discord_message(
+            alert_group=alert_group, message_type=DiscordMessage.ALERT_GROUP_MESSAGE, thread_id=thread_id
+        )
+        note = make_resolution_note(
+            alert_group=alert_group,
+            source=ResolutionNote.Source.WEB,
+            author=user,
+            message_text="Subject: the queue waits.\n\nWhat started it: depth stayed high for 15 minutes.",
+        )
+        if deleted:
+            note.delete()
+            note = ResolutionNote.objects_with_deleted.get(pk=note.pk)
+        return alert_group, note, message, channel
+
+    return _posted_note
+
+
+@pytest.mark.django_db
+def test_a_forum_permalink_is_the_post(posted_note):
+    alert_group, _, message, channel = posted_note(thread_id="1300000000000000009")
+
+    assert (
+        alert_group.discord_permalink
+        == f"https://discord.com/channels/{channel.guild_id}/{message.thread_id}"
+    )
+    assert alert_group.permalinks["discord"] == alert_group.discord_permalink
+
+
+@pytest.mark.django_db
+def test_a_channel_permalink_points_at_the_card(posted_note):
+    alert_group, _, message, channel = posted_note()
+
+    assert alert_group.discord_permalink == (
+        f"https://discord.com/channels/{channel.guild_id}/{message.channel_id}/{message.message_id}"
+    )
+
+
+@pytest.mark.django_db
+def test_permalinks_are_empty_without_a_card(
+    make_organization, make_discord_channel, make_alert_receive_channel, make_alert_group
+):
+    organization = make_organization()
+    make_discord_channel(organization=organization, is_default_channel=True)
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel=alert_receive_channel)
+
+    assert alert_group.discord_permalink is None
+    assert alert_group.permalinks["discord"] is None
+
+
+@pytest.mark.django_db
+def test_a_note_in_a_forum_post_needs_no_reply(posted_note):
+    alert_group, note, _, _ = posted_note(thread_id="1300000000000000009")
+
+    with patch("apps.discord.alert_group_representative.DiscordClient.create_message") as create_message, patch(
+        "apps.discord.alert_group_representative.DiscordClient.update_thread"
+    ) as update_thread:
+        AlertGroupDiscordRepresentative.post_resolution_note(alert_group, note)
+
+    update_thread.assert_called_once_with(thread_id="1300000000000000009", archived=False)
+    _, kwargs = create_message.call_args
+    assert kwargs["channel_id"] == "1300000000000000009"
+    assert "message_reference" not in kwargs["data"]
+    assert kwargs["data"]["embeds"][0]["title"] == "Investigation"
+    assert "the queue waits" in kwargs["data"]["embeds"][0]["description"]
+    assert kwargs["data"]["embeds"][0]["footer"]["text"] == "Note from investigator"
+    assert kwargs["data"]["allowed_mentions"] == {"parse": []}
+    assert kwargs["nonce"] == f"rn-{note.pk}"
+
+
+@pytest.mark.django_db
+def test_a_note_in_a_text_channel_quotes_the_card(posted_note):
+    alert_group, note, message, _ = posted_note()
+
+    with patch("apps.discord.alert_group_representative.DiscordClient.create_message") as create_message, patch(
+        "apps.discord.alert_group_representative.DiscordClient.update_thread"
+    ) as update_thread:
+        AlertGroupDiscordRepresentative.post_resolution_note(alert_group, note)
+
+    update_thread.assert_not_called()
+    _, kwargs = create_message.call_args
+    assert kwargs["channel_id"] == message.channel_id
+    assert kwargs["data"]["message_reference"]["message_id"] == message.message_id
+
+
+@pytest.mark.django_db
+def test_a_deleted_note_is_not_posted(posted_note):
+    alert_group, note, _, _ = posted_note(deleted=True)
+
+    with patch("apps.discord.alert_group_representative.DiscordClient.create_message") as create_message:
+        AlertGroupDiscordRepresentative.post_resolution_note(alert_group, note)
+        on_resolution_note_async(note.pk)
+
+    create_message.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_the_task_retries_until_the_card_exists(
+    make_organization,
+    make_user_for_organization,
+    make_discord_channel,
+    make_alert_receive_channel,
+    make_alert_group,
+    make_resolution_note,
+):
+    organization = make_organization()
+    user = make_user_for_organization(organization)
+    make_discord_channel(organization=organization, is_default_channel=True)
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel=alert_receive_channel)
+    note = make_resolution_note(alert_group=alert_group, source=ResolutionNote.Source.WEB, author=user)
+
+    with pytest.raises(DiscordMessage.DoesNotExist):
+        on_resolution_note_async(note.pk)
+
+
+@pytest.mark.django_db
+def test_the_signal_queues_the_note_task(posted_note):
+    _, note, _, _ = posted_note()
+
+    with patch("apps.discord.alert_group_representative.on_resolution_note_async.apply_async") as apply_async:
+        AlertGroupDiscordRepresentative.on_alert_group_update_resolution_note(
+            alert_group=note.alert_group, resolution_note=note
+        )
+
+    apply_async.assert_called_once_with((note.pk,))

--- a/engine/apps/discord/tests/test_resolution_note.py
+++ b/engine/apps/discord/tests/test_resolution_note.py
@@ -6,7 +6,9 @@ import pytest
 
 from apps.alerts.models import AlertReceiveChannel, ResolutionNote
 from apps.discord.alert_group_representative import AlertGroupDiscordRepresentative
-from apps.discord.models import DiscordMessage
+from apps.discord.client import DiscordMessage as DiscordAPIMessage
+from apps.discord.exceptions import DiscordAPIException
+from apps.discord.models import DiscordMessage, DiscordResolutionNoteMessage
 from apps.discord.tasks import on_resolution_note_async
 
 
@@ -33,7 +35,11 @@ def posted_note(
         alert_group = make_alert_group(alert_receive_channel=alert_receive_channel)
         make_alert(alert_group=alert_group, raw_request_data=alert_receive_channel.config.example_payload)
         message = make_discord_message(
-            alert_group=alert_group, message_type=DiscordMessage.ALERT_GROUP_MESSAGE, thread_id=thread_id
+            alert_group=alert_group,
+            message_type=DiscordMessage.ALERT_GROUP_MESSAGE,
+            channel_id=channel.channel_id,
+            guild_id=channel.guild_id,
+            thread_id=thread_id,
         )
         note = make_resolution_note(
             alert_group=alert_group,
@@ -53,10 +59,7 @@ def posted_note(
 def test_a_forum_permalink_is_the_post(posted_note):
     alert_group, _, message, channel = posted_note(thread_id="1300000000000000009")
 
-    assert (
-        alert_group.discord_permalink
-        == f"https://discord.com/channels/{channel.guild_id}/{message.thread_id}"
-    )
+    assert alert_group.discord_permalink == f"https://discord.com/channels/{channel.guild_id}/{message.thread_id}"
     assert alert_group.permalinks["discord"] == alert_group.discord_permalink
 
 
@@ -67,6 +70,17 @@ def test_a_channel_permalink_points_at_the_card(posted_note):
     assert alert_group.discord_permalink == (
         f"https://discord.com/channels/{channel.guild_id}/{message.channel_id}/{message.message_id}"
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("thread_id", [None, "1300000000000000009"])
+def test_a_permalink_survives_channel_disconnection(posted_note, thread_id):
+    alert_group, _, _, channel = posted_note(thread_id=thread_id)
+    permalink = alert_group.discord_permalink
+
+    channel.delete()
+
+    assert alert_group.discord_permalink == permalink
 
 
 @pytest.mark.django_db
@@ -84,11 +98,12 @@ def test_permalinks_are_empty_without_a_card(
 
 @pytest.mark.django_db
 def test_a_note_in_a_forum_post_needs_no_reply(posted_note):
-    alert_group, note, _, _ = posted_note(thread_id="1300000000000000009")
+    alert_group, note, message, _ = posted_note(thread_id="1300000000000000009")
+    posted = DiscordAPIMessage(message_id="1300000000000000010", channel_id=message.thread_id)
 
-    with patch("apps.discord.alert_group_representative.DiscordClient.create_message") as create_message, patch(
-        "apps.discord.alert_group_representative.DiscordClient.update_thread"
-    ) as update_thread:
+    with patch(
+        "apps.discord.alert_group_representative.DiscordClient.create_message", return_value=posted
+    ) as create_message, patch("apps.discord.alert_group_representative.DiscordClient.update_thread") as update_thread:
         AlertGroupDiscordRepresentative.post_resolution_note(alert_group, note)
 
     update_thread.assert_called_once_with(thread_id="1300000000000000009", archived=False)
@@ -100,21 +115,80 @@ def test_a_note_in_a_forum_post_needs_no_reply(posted_note):
     assert kwargs["data"]["embeds"][0]["footer"]["text"] == "Note from investigator"
     assert kwargs["data"]["allowed_mentions"] == {"parse": []}
     assert kwargs["nonce"] == f"rn-{note.pk}"
+    assert DiscordResolutionNoteMessage.objects.get(resolution_note=note).message_id == posted.message_id
 
 
 @pytest.mark.django_db
 def test_a_note_in_a_text_channel_quotes_the_card(posted_note):
     alert_group, note, message, _ = posted_note()
+    posted = DiscordAPIMessage(message_id="1300000000000000010", channel_id=message.channel_id)
 
-    with patch("apps.discord.alert_group_representative.DiscordClient.create_message") as create_message, patch(
-        "apps.discord.alert_group_representative.DiscordClient.update_thread"
-    ) as update_thread:
+    with patch(
+        "apps.discord.alert_group_representative.DiscordClient.create_message", return_value=posted
+    ) as create_message, patch("apps.discord.alert_group_representative.DiscordClient.update_thread") as update_thread:
         AlertGroupDiscordRepresentative.post_resolution_note(alert_group, note)
 
     update_thread.assert_not_called()
     _, kwargs = create_message.call_args
     assert kwargs["channel_id"] == message.channel_id
     assert kwargs["data"]["message_reference"]["message_id"] == message.message_id
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("thread_id", [None, "1300000000000000009"])
+def test_an_edited_note_updates_the_existing_message_without_the_card_record(posted_note, thread_id):
+    _, note, message, _ = posted_note(thread_id=thread_id)
+    note_message = DiscordResolutionNoteMessage.objects.create(
+        resolution_note=note,
+        channel_id=message.thread_id or message.channel_id,
+        message_id="1300000000000000010",
+        thread_id=message.thread_id,
+    )
+    message.delete()
+    note.message_text = "The queue recovered."
+    note.save(update_fields=["message_text"])
+
+    with patch("apps.discord.alert_group_representative.DiscordClient.update_message") as update_message, patch(
+        "apps.discord.alert_group_representative.DiscordClient.create_message"
+    ) as create_message, patch("apps.discord.alert_group_representative.DiscordClient.update_thread") as update_thread:
+        on_resolution_note_async(note.pk)
+
+    create_message.assert_not_called()
+    update_message.assert_called_once()
+    assert update_message.call_args.kwargs["channel_id"] == note_message.channel_id
+    assert "The queue recovered" in update_message.call_args.kwargs["data"]["embeds"][0]["description"]
+    if thread_id:
+        update_thread.assert_called_once_with(thread_id=thread_id, archived=False)
+    else:
+        update_thread.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("thread_id", [None, "1300000000000000009"])
+@pytest.mark.parametrize("missing_remotely", [False, True])
+def test_a_deleted_note_removes_the_existing_message(posted_note, thread_id, missing_remotely):
+    alert_group, note, message, _ = posted_note(thread_id=thread_id)
+    note_message = DiscordResolutionNoteMessage.objects.create(
+        resolution_note=note,
+        channel_id=message.thread_id or message.channel_id,
+        message_id="1300000000000000010",
+        thread_id=message.thread_id,
+    )
+    note.delete()
+    note = ResolutionNote.objects_with_deleted.get(pk=note.pk)
+    error = DiscordAPIException(status=404, url="unused", method="DELETE") if missing_remotely else None
+
+    with patch(
+        "apps.discord.alert_group_representative.DiscordClient.delete_message", side_effect=error
+    ) as delete_message, patch("apps.discord.alert_group_representative.DiscordClient.update_thread") as update_thread:
+        AlertGroupDiscordRepresentative.post_resolution_note(alert_group, note)
+
+    delete_message.assert_called_once_with(channel_id=note_message.channel_id, message_id=note_message.message_id)
+    if thread_id:
+        update_thread.assert_called_once_with(thread_id=thread_id, archived=False)
+    else:
+        update_thread.assert_not_called()
+    assert not DiscordResolutionNoteMessage.objects.filter(pk=note_message.pk).exists()
 
 
 @pytest.mark.django_db

--- a/engine/apps/public_api/serializers/alert_groups.py
+++ b/engine/apps/public_api/serializers/alert_groups.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models import Prefetch
 from rest_framework import serializers
 
@@ -47,6 +48,18 @@ class AlertGroupSerializer(EagerLoadingMixin, serializers.ModelSerializer):
             to_attr="prefetched_telegram_messages",
         ),
     ]
+    if settings.FEATURE_DISCORD_INTEGRATION_ENABLED:
+        from apps.discord.models import DiscordMessage
+
+        PREFETCH_RELATED = PREFETCH_RELATED + [
+            Prefetch(
+                "discord_messages",
+                queryset=DiscordMessage.objects.filter(message_type=DiscordMessage.ALERT_GROUP_MESSAGE).order_by(
+                    "created_at"
+                )[:1],
+                to_attr="prefetched_discord_messages",
+            ),
+        ]
 
     class Meta:
         model = AlertGroup

--- a/engine/apps/public_api/tests/test_alert_groups.py
+++ b/engine/apps/public_api/tests/test_alert_groups.py
@@ -71,6 +71,7 @@ def construct_expected_response_from_alert_groups(alert_groups):
                     "slack": None,
                     "slack_app": None,
                     "telegram": None,
+                    "discord": None,
                     "web": alert_group.web_link,
                 },
                 "silenced_at": silenced_at,

--- a/engine/apps/public_api/tests/test_escalation.py
+++ b/engine/apps/public_api/tests/test_escalation.py
@@ -71,6 +71,7 @@ def test_escalation_new_alert_group(
             "slack": None,
             "slack_app": None,
             "telegram": None,
+            "discord": None,
             "web": f"a/{PluginID.ONCALL}/alert-groups/{ag.public_primary_key}",
         },
         "silenced_at": None,

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -196,6 +196,7 @@ CELERY_TASK_ROUTES = {
     # DISCORD
     "apps.discord.tasks.on_create_alert_async": {"queue": "discord"},
     "apps.discord.tasks.on_alert_group_action_triggered_async": {"queue": "discord"},
+    "apps.discord.tasks.on_resolution_note_async": {"queue": "discord"},
     "apps.discord.tasks.notify_user_about_alert_async": {"queue": "discord"},
     "apps.discord.shifts.announce_shift_starts_for_schedule": {"queue": "discord"},
     "apps.discord.shifts.announce_shift_starts_for_all_schedules": {"queue": "discord"},

--- a/grafana-plugin/src/network/oncall-api/autogenerated-api.types.d.ts
+++ b/grafana-plugin/src/network/oncall-api/autogenerated-api.types.d.ts
@@ -1547,6 +1547,7 @@ export interface components {
         slack: string | null;
         slack_app: string | null;
         telegram: string | null;
+        discord: string | null;
         web: string;
       };
       readonly alerts: components['schemas']['Alert'][];
@@ -1659,6 +1660,7 @@ export interface components {
         slack: string | null;
         slack_app: string | null;
         telegram: string | null;
+        discord: string | null;
         web: string;
       };
     };


### PR DESCRIPTION
## Summary
- A resolution note created from the UI or the public API is posted beside the Discord card, the same place escalation pings land. Forum posts are unarchived first. Mentions stay off.
- Alert groups now carry `permalinks.discord`: the forum post, or the card in a text channel.
- Slack already did this. Discord did not, so a note written for the existing thread never reached it.

## Test plan
- [ ] Discord suite: `pytest engine/apps/discord/tests/test_resolution_note.py engine/apps/discord/tests/test_escalation.py`
- [ ] Public API permalinks still serialize: `pytest engine/apps/public_api/tests/test_alert_groups.py engine/apps/public_api/tests/test_escalation.py`
- [ ] Create a resolution note on a firing forum post and confirm it lands in that post
- [ ] Create a note on a text-channel card and confirm it replies to the card
- [ ] Confirm `permalinks.discord` on `GET /api/v1/alert_groups/{id}`


Made with [Cursor](https://cursor.com)