### PR TITLE
feat(discord): name each instance an alert group holds

### DIFF
--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -631,6 +631,84 @@ def test_a_card_does_not_list_the_one_instance_it_already_describes():
     assert rendered.count("The `builds` queue gained 12 failed jobs in an hour.") == 1
 
 
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_lists_the_one_instance_of_a_group_that_says_anything(integration):
+    """Whether a group is listed is decided by how many alerts it holds, not by how many of them had something
+    to say.
+
+    An instance whose labels are all common to the group and whose rule wrote no summary adds no line. Counting
+    lines rather than alerts, a pair like that read as a group of one and threw away the only line naming what
+    had failed.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {
+                "alertname": "Queue has failed jobs",
+                "deployment_region_name": "fra",
+                "team": "cloud",
+            },
+            "commonAnnotations": {"description": "This alert starts when a queue is holding more failed jobs."},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {
+                        "alertname": "Queue has failed jobs",
+                        "deployment_region_name": "fra",
+                        "k8s_cluster_name": "cloud-fra1-prod",
+                        "service_name": "builds",
+                        "team": "cloud",
+                    },
+                    "annotations": {"summary": "The `builds` queue on `cloud-fra1-prod` has failed 2384 more jobs."},
+                },
+                {
+                    "status": "firing",
+                    "labels": {
+                        "alertname": "Queue has failed jobs",
+                        "deployment_region_name": "fra",
+                        "team": "cloud",
+                    },
+                    "annotations": {},
+                },
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert "**Instances**" in lines
+    assert "- The `builds` queue on `cloud-fra1-prod` has failed 2384 more jobs." in lines
+    # The names the group does not share, which no other line on the card carries.
+    for name in ("builds", "cloud-fra1-prod"):
+        assert name in rendered, f"{name} is in no common label and is on no other line"
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_says_an_instance_line_once(integration):
+    """A group whose alerts were all written the same sentence has that sentence in commonAnnotations already,
+    and a list of it repeats one line per alert."""
+    shared = "A queue is holding more failed jobs than it was."
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+            "commonAnnotations": {"summary": shared},
+            "alerts": [
+                {"status": "firing", "labels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+                 "annotations": {"summary": shared}}
+                for _ in range(3)
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+
+    assert rendered.count(shared) == 1
+
+
 @pytest.mark.django_db
 def test_a_dashboard_annotation_becomes_a_button_of_its_own(
     make_organization, make_user_for_organization, make_alert_receive_channel, make_alert_group, make_alert

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -592,7 +592,7 @@ def test_a_card_names_each_instance_a_group_holds(integration):
     )
     lines = rendered.splitlines()
 
-    assert "**Instances**" in lines
+    assert "**Summaries**" in lines
     for instance in (
         "- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour.",
         "- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour.",
@@ -626,7 +626,7 @@ def test_a_card_does_not_list_the_one_instance_it_already_describes():
         integration_name="Grafana Alerting",
     )
 
-    assert "**Instances**" not in rendered.splitlines()
+    assert "**Summaries**" not in rendered.splitlines()
     # Said once, by the summary that a group of one puts in commonAnnotations.
     assert rendered.count("The `builds` queue gained 12 failed jobs in an hour.") == 1
 
@@ -678,7 +678,7 @@ def test_a_card_lists_the_one_instance_of_a_group_that_says_anything(integration
     )
     lines = rendered.splitlines()
 
-    assert "**Instances**" in lines
+    assert "**Summaries**" in lines
     assert "- The `builds` queue on `cloud-fra1-prod` has failed 2384 more jobs." in lines
     # The names the group does not share, which no other line on the card carries.
     for name in ("builds", "cloud-fra1-prod"):
@@ -742,7 +742,7 @@ def test_a_card_names_instances_a_shared_sentence_does_not(integration):
     )
     lines = [line for line in rendered.splitlines() if line.startswith("- ")]
 
-    assert "**Instances**" in rendered.splitlines()
+    assert "**Summaries**" in rendered.splitlines()
     # One line per alert, and each names the instance its sentence did not.
     for region, node in (("fra", "node-1"), ("syd", "node-2"), ("tor", "node-3")):
         assert any(f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines), (
@@ -812,6 +812,56 @@ def test_an_instance_line_does_not_repeat_what_its_summary_already_says(integrat
     assert "- The `domains` queue on `cloud-syd1-prod` has failed 12 more jobs." in lines
     # The labels the sentence already carries are not appended to it.
     assert not any("service_name:" in line for line in lines)
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_keeps_what_the_route_grouped_by_apart_from_what_the_alerts_share(integration):
+    """Two questions, two headings.
+
+    `groupLabels` says why these alerts arrived as one card; `commonLabels` says what they turned out to have in
+    common once they had. Merged under one heading a reader cannot tell which is which, and the label that
+    explains the grouping is buried among labels that merely happen to agree.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            # The default Grafana policy: group_by = [grafana_folder, alertname].
+            "groupLabels": {"grafana_folder": "Utopia", "alertname": "Queue has failed jobs"},
+            "commonLabels": {
+                "alertname": "Queue has failed jobs",
+                "grafana_folder": "Utopia",
+                "deployment_cluster_name": "cloud",
+                "severity": "warning",
+                "team": "cloud",
+            },
+            "commonAnnotations": {"description": "A queue is holding more failed jobs than it was."},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "grafana_folder": "Utopia",
+                               "deployment_cluster_name": "cloud", "severity": "warning", "team": "cloud",
+                               "service_name": service},
+                    "annotations": {"summary": f"The `{service}` queue has failed 12 more jobs."},
+                }
+                for service in ("builds", "domains")
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert "**Group**" in lines
+    assert "**Labels**" in lines
+    group = lines.index("**Group**")
+    labels = lines.index("**Labels**")
+    # What the route grouped by, under Group. alertname is the card's title, so it is not a line.
+    assert "- grafana_folder: `Utopia`" in lines[group:labels]
+    assert not any("alertname:" in line for line in lines)
+    # What they merely share, under Labels, and not repeated under Group.
+    assert "- deployment_cluster_name: `cloud`" in lines[labels:]
+    assert "- team: `cloud`" in lines[labels:]
+    assert rendered.count("grafana_folder") == 1, "a label belongs to one heading, not both"
 
 
 @pytest.mark.django_db

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -593,13 +593,14 @@ def test_a_card_names_each_instance_a_group_holds(integration):
     lines = rendered.splitlines()
 
     assert "**Summaries**" in lines
-    # The sentence says the queue and the cluster as words of their own; the region hides in the cluster's name
-    # as a syllable, which is not saying it, so the line carries it.
     for instance in (
-        "- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour. — deployment_region_name: `fra`",
-        "- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour. — deployment_region_name: `syd`",
+        "- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour.",
+        "- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour.",
     ):
         assert instance in lines, f"{instance} should be a line of its own"
+    # The sentence says the queue and the cluster as words of their own; the region hides in the cluster's name
+    # as a syllable, which is not saying it, so it is kept — gathered by key rather than trailing the sentence.
+    assert "- deployment_region_name: `fra`, `syd`" in lines
     # The names that only the instances carry, which is the whole reason the card lists them.
     for name in ("builds", "domains", "cloud-fra1-prod", "cloud-syd1-prod"):
         assert name in rendered, f"{name} is in no common label and would be lost"
@@ -724,8 +725,9 @@ def test_a_card_names_instances_a_shared_sentence_does_not(integration):
     """A summary is prose, not an identity.
 
     A rule is free to write two instances the same sentence, and then that sentence identifies neither of them.
-    Taking the sentence as the instance's line collapsed the pair into one entry naming no region and no node,
-    so a card reported two full disks as one and named neither.
+    Taking the sentence as the whole of the instance's line, a card reported two full disks as one and named
+    neither. The sentences read as prose — repeated ones once — and every region and node the group holds is
+    counted in the gathered labels below.
     """
     rendered = apply_jinja_template(
         import_module(f"config_integrations.{integration}").discord_message,
@@ -742,16 +744,14 @@ def test_a_card_names_instances_a_shared_sentence_does_not(integration):
         source_link="",
         integration_name="Grafana Alerting",
     )
-    lines = [line for line in rendered.splitlines() if line.startswith("- ")]
+    lines = rendered.splitlines()
 
-    assert "**Summaries**" in rendered.splitlines()
-    # One line per alert, and each names the instance its sentence did not.
-    for region, node in (("fra", "node-1"), ("syd", "node-2"), ("tor", "node-3")):
-        assert any(f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines), (
-            f"{region}/{node} is named nowhere on the card"
-        )
-    # The sentence two of them share is still said against each of them, not collapsed into one entry.
-    assert len([line for line in lines if "Disk is nearly full." in line]) == 2
+    assert "**Summaries**" in lines
+    assert "- Disk is nearly full." in lines
+    assert "- Root volume is nearly full." in lines
+    # Every region and node the group holds, counted whether or not its sentence was its own.
+    assert "- region: `fra`, `syd`, `tor`" in lines
+    assert "- instance: `node-1`, `node-2`, `node-3`" in lines
 
 
 @pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
@@ -841,8 +841,9 @@ def test_a_summary_carries_a_label_as_a_word_and_not_as_a_syllable(integration):
     )
     lines = rendered.splitlines()
 
-    assert "- The queue gained 11 failed jobs. — shard: `1`" in lines
-    assert "- The queue gained 13 failed jobs. — shard: `3`" in lines
+    assert "- The queue gained 11 failed jobs." in lines
+    assert "- The queue gained 13 failed jobs." in lines
+    assert "- shard: `1`, `3`" in lines
 
 
 @pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -700,8 +700,11 @@ def test_a_card_says_an_instance_line_once(integration):
             "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
             "commonAnnotations": {"summary": shared},
             "alerts": [
-                {"status": "firing", "labels": {"alertname": "Queue has failed jobs", "team": "cloud"},
-                 "annotations": {"summary": shared}}
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+                    "annotations": {"summary": shared},
+                }
                 for _ in range(3)
             ],
         },
@@ -779,9 +782,9 @@ def test_a_card_names_instances_when_every_summary_is_the_same(integration):
     lines = [line for line in rendered.splitlines() if line.startswith("- ")]
 
     for region, node in (("fra", "node-1"), ("syd", "node-2"), ("tor", "node-3")):
-        assert any(f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines), (
-            f"{region}/{node} is named nowhere on the card"
-        )
+        assert any(
+            f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines
+        ), f"{region}/{node} is named nowhere on the card"
     # Said once, at the top, rather than again on every line below it.
     assert rendered.count("Disk is nearly full.") == 1
 
@@ -798,8 +801,12 @@ def test_an_instance_line_does_not_repeat_what_its_summary_already_says(integrat
             "alerts": [
                 {
                     "status": "firing",
-                    "labels": {"alertname": "Queue has failed jobs", "team": "cloud",
-                               "service_name": service, "k8s_cluster_name": cluster},
+                    "labels": {
+                        "alertname": "Queue has failed jobs",
+                        "team": "cloud",
+                        "service_name": service,
+                        "k8s_cluster_name": cluster,
+                    },
                     "annotations": {"summary": f"The `{service}` queue on `{cluster}` has failed 12 more jobs."},
                 }
                 for service, cluster in (("builds", "cloud-fra1-prod"), ("domains", "cloud-syd1-prod"))
@@ -831,8 +838,11 @@ def test_a_summary_carries_a_label_as_a_word_and_not_as_a_syllable(integration):
             "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
             "commonAnnotations": {},
             "alerts": [
-                {"status": "firing", "labels": {"alertname": "Queue has failed jobs", "team": "cloud", "shard": shard},
-                 "annotations": {"summary": f"The queue gained 1{shard} failed jobs."}}
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "team": "cloud", "shard": shard},
+                    "annotations": {"summary": f"The queue gained 1{shard} failed jobs."},
+                }
                 for shard in ("1", "3")
             ],
         },
@@ -861,8 +871,11 @@ def test_a_lone_varying_label_gathers_onto_one_line(integration):
             "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
             "commonAnnotations": {},
             "alerts": [
-                {"status": "firing", "labels": {"alertname": "Queue has failed jobs", "team": "cloud", "shard": shard},
-                 "annotations": {"summary": "The queue gained 12 failed jobs."}}
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "team": "cloud", "shard": shard},
+                    "annotations": {"summary": "The queue gained 12 failed jobs."},
+                }
                 for shard in ("1", "2")
             ],
         },
@@ -916,14 +929,24 @@ def test_a_summary_carries_a_label_even_wrapped_in_punctuation(integration):
             "commonLabels": {"alertname": "Queue has failed jobs"},
             "commonAnnotations": {},
             "alerts": [
-                {"status": "firing",
-                 "labels": {"alertname": "Queue has failed jobs", "service_name": "builds",
-                            "k8s_cluster_name": "cloud-fra1-prod"},
-                 "annotations": {"summary": "The `builds` queue failed on cloud-fra1-prod."}},
-                {"status": "firing",
-                 "labels": {"alertname": "Queue has failed jobs", "service_name": "domains",
-                            "k8s_cluster_name": "cloud-syd1-prod"},
-                 "annotations": {"summary": "The `domains` queue failed on cloud-syd1-prod."}},
+                {
+                    "status": "firing",
+                    "labels": {
+                        "alertname": "Queue has failed jobs",
+                        "service_name": "builds",
+                        "k8s_cluster_name": "cloud-fra1-prod",
+                    },
+                    "annotations": {"summary": "The `builds` queue failed on cloud-fra1-prod."},
+                },
+                {
+                    "status": "firing",
+                    "labels": {
+                        "alertname": "Queue has failed jobs",
+                        "service_name": "domains",
+                        "k8s_cluster_name": "cloud-syd1-prod",
+                    },
+                    "annotations": {"summary": "The `domains` queue failed on cloud-syd1-prod."},
+                },
             ],
         },
         source_link="",
@@ -962,9 +985,14 @@ def test_a_card_keeps_what_the_route_grouped_by_apart_from_what_the_alerts_share
             "alerts": [
                 {
                     "status": "firing",
-                    "labels": {"alertname": "Queue has failed jobs", "grafana_folder": "Utopia",
-                               "deployment_cluster_name": "cloud", "severity": "warning", "team": "cloud",
-                               "service_name": service},
+                    "labels": {
+                        "alertname": "Queue has failed jobs",
+                        "grafana_folder": "Utopia",
+                        "deployment_cluster_name": "cloud",
+                        "severity": "warning",
+                        "team": "cloud",
+                        "service_name": service,
+                    },
                     "annotations": {"summary": f"The `{service}` queue has failed 12 more jobs."},
                 }
                 for service in ("builds", "domains")

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -535,6 +535,102 @@ def test_a_card_says_something_when_the_alert_carries_no_annotations():
     assert "- instance: `localhost:8082`" in rendered.splitlines()
 
 
+# The default Grafana route groups by grafana_folder and alertname only, so one rule watching many workers in many
+# regions arrives as a single group. service_name differs between the instances, which keeps it out of
+# commonLabels, and each summary is written from it, which keeps every summary out of commonAnnotations.
+QUEUE_FAILURES_PAYLOAD = {
+    "status": "firing",
+    "groupLabels": {"alertname": "Queue has failed jobs"},
+    "commonLabels": {
+        "alertname": "Queue has failed jobs",
+        "deployment_cluster_name": "cloud",
+        "grafana_folder": "Utopia",
+        "severity": "warning",
+        "team": "cloud",
+    },
+    "commonAnnotations": {"description": "This alert starts when a queue is holding more failed jobs than it was."},
+    "alerts": [
+        {
+            "status": "firing",
+            "labels": {
+                "alertname": "Queue has failed jobs",
+                "deployment_region_name": "fra",
+                "k8s_cluster_name": "cloud-fra1-prod",
+                "service_name": "builds",
+                "severity": "warning",
+            },
+            "annotations": {"summary": "The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour."},
+        },
+        {
+            "status": "firing",
+            "labels": {
+                "alertname": "Queue has failed jobs",
+                "deployment_region_name": "syd",
+                "k8s_cluster_name": "cloud-syd1-prod",
+                "service_name": "domains",
+                "severity": "warning",
+            },
+            "annotations": {"summary": "The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour."},
+        },
+    ],
+}
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_names_each_instance_a_group_holds(integration):
+    """A group of many says what is in it.
+
+    The card can only print what the instances share, and what they share is the part that does not identify
+    them. Without a line per instance the reader is told a queue somewhere has failed jobs and not which queue.
+    """
+    config = import_module(f"config_integrations.{integration}")
+    rendered = apply_jinja_template(
+        config.discord_message,
+        payload=QUEUE_FAILURES_PAYLOAD,
+        source_link="https://grafana.example/alerting/list",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert "**Instances**" in lines
+    for instance in (
+        "- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour.",
+        "- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour.",
+    ):
+        assert instance in lines, f"{instance} should be a line of its own"
+    # The names that only the instances carry, which is the whole reason the card lists them.
+    for name in ("builds", "domains", "cloud-fra1-prod", "cloud-syd1-prod"):
+        assert name in rendered, f"{name} is in no common label and would be lost"
+    # What they do share is still said once, above.
+    assert "This alert starts when a queue is holding more failed jobs than it was." in rendered
+    assert "- team: `cloud`" in lines
+
+
+def test_a_card_does_not_list_the_one_instance_it_already_describes():
+    """A group of one has its labels and its summary in the lines above, so a list of it repeats them."""
+    rendered = apply_jinja_template(
+        import_module("config_integrations.grafana_alerting").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs", "service_name": "builds"},
+            "commonLabels": {"alertname": "Queue has failed jobs", "service_name": "builds"},
+            "commonAnnotations": {"summary": "The `builds` queue gained 12 failed jobs in an hour."},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "service_name": "builds"},
+                    "annotations": {"summary": "The `builds` queue gained 12 failed jobs in an hour."},
+                }
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+
+    assert "**Instances**" not in rendered.splitlines()
+    # Said once, by the summary that a group of one puts in commonAnnotations.
+    assert rendered.count("The `builds` queue gained 12 failed jobs in an hour.") == 1
+
+
 @pytest.mark.django_db
 def test_a_dashboard_annotation_becomes_a_button_of_its_own(
     make_organization, make_user_for_organization, make_alert_receive_channel, make_alert_group, make_alert

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -709,6 +709,111 @@ def test_a_card_says_an_instance_line_once(integration):
     assert rendered.count(shared) == 1
 
 
+def _disk_alert(region, node, summary):
+    return {
+        "status": "firing",
+        "labels": {"alertname": "Disk filling", "team": "cloud", "region": region, "instance": node},
+        "annotations": {"summary": summary},
+    }
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_names_instances_a_shared_sentence_does_not(integration):
+    """A summary is prose, not an identity.
+
+    A rule is free to write two instances the same sentence, and then that sentence identifies neither of them.
+    Taking the sentence as the instance's line collapsed the pair into one entry naming no region and no node,
+    so a card reported two full disks as one and named neither.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Disk filling"},
+            "commonLabels": {"alertname": "Disk filling", "team": "cloud"},
+            "commonAnnotations": {"description": "A disk is above its watermark."},
+            "alerts": [
+                _disk_alert("fra", "node-1", "Disk is nearly full."),
+                _disk_alert("syd", "node-2", "Disk is nearly full."),
+                _disk_alert("tor", "node-3", "Root volume is nearly full."),
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = [line for line in rendered.splitlines() if line.startswith("- ")]
+
+    assert "**Instances**" in rendered.splitlines()
+    # One line per alert, and each names the instance its sentence did not.
+    for region, node in (("fra", "node-1"), ("syd", "node-2"), ("tor", "node-3")):
+        assert any(f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines), (
+            f"{region}/{node} is named nowhere on the card"
+        )
+    # The sentence two of them share is still said against each of them, not collapsed into one entry.
+    assert len([line for line in lines if "Disk is nearly full." in line]) == 2
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_card_names_instances_when_every_summary_is_the_same(integration):
+    """The same defect with every alert written the same sentence, which puts it in commonAnnotations.
+
+    The card says that sentence once at the top. What is left to tell the instances apart is their labels, so a
+    line carries those and not the sentence again.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Disk filling"},
+            "commonLabels": {"alertname": "Disk filling", "team": "cloud"},
+            "commonAnnotations": {"summary": "Disk is nearly full."},
+            "alerts": [
+                _disk_alert("fra", "node-1", "Disk is nearly full."),
+                _disk_alert("syd", "node-2", "Disk is nearly full."),
+                _disk_alert("tor", "node-3", "Disk is nearly full."),
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = [line for line in rendered.splitlines() if line.startswith("- ")]
+
+    for region, node in (("fra", "node-1"), ("syd", "node-2"), ("tor", "node-3")):
+        assert any(f"region: `{region}`" in line and f"instance: `{node}`" in line for line in lines), (
+            f"{region}/{node} is named nowhere on the card"
+        )
+    # Said once, at the top, rather than again on every line below it.
+    assert rendered.count("Disk is nearly full.") == 1
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_an_instance_line_does_not_repeat_what_its_summary_already_says(integration):
+    """A rule that names the instance in its summary has said it, and the line does not say it twice."""
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+            "commonAnnotations": {"description": "A queue is holding more failed jobs than it was."},
+            "alerts": [
+                {
+                    "status": "firing",
+                    "labels": {"alertname": "Queue has failed jobs", "team": "cloud",
+                               "service_name": service, "k8s_cluster_name": cluster},
+                    "annotations": {"summary": f"The `{service}` queue on `{cluster}` has failed 12 more jobs."},
+                }
+                for service, cluster in (("builds", "cloud-fra1-prod"), ("domains", "cloud-syd1-prod"))
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = [line for line in rendered.splitlines() if line.startswith("- ")]
+
+    assert "- The `builds` queue on `cloud-fra1-prod` has failed 12 more jobs." in lines
+    assert "- The `domains` queue on `cloud-syd1-prod` has failed 12 more jobs." in lines
+    # The labels the sentence already carries are not appended to it.
+    assert not any("service_name:" in line for line in lines)
+
+
 @pytest.mark.django_db
 def test_a_dashboard_annotation_becomes_a_button_of_its_own(
     make_organization, make_user_for_organization, make_alert_receive_channel, make_alert_group, make_alert

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -593,9 +593,11 @@ def test_a_card_names_each_instance_a_group_holds(integration):
     lines = rendered.splitlines()
 
     assert "**Summaries**" in lines
+    # The sentence says the queue and the cluster as words of their own; the region hides in the cluster's name
+    # as a syllable, which is not saying it, so the line carries it.
     for instance in (
-        "- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour.",
-        "- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour.",
+        "- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour. — deployment_region_name: `fra`",
+        "- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour. — deployment_region_name: `syd`",
     ):
         assert instance in lines, f"{instance} should be a line of its own"
     # The names that only the instances carry, which is the whole reason the card lists them.
@@ -812,6 +814,67 @@ def test_an_instance_line_does_not_repeat_what_its_summary_already_says(integrat
     assert "- The `domains` queue on `cloud-syd1-prod` has failed 12 more jobs." in lines
     # The labels the sentence already carries are not appended to it.
     assert not any("service_name:" in line for line in lines)
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_summary_carries_a_label_as_a_word_and_not_as_a_syllable(integration):
+    """A sentence carries a label when it says it as a word of its own, not when the characters happen to occur.
+
+    Matched anywhere in the sentence, `shard: 1` was read into "12 jobs" and dropped, and with every alert
+    written the same sentence the lines collapsed to one — the very defect naming instances was meant to fix,
+    reachable again through any label short enough to hide inside a number.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+            "commonAnnotations": {},
+            "alerts": [
+                {"status": "firing", "labels": {"alertname": "Queue has failed jobs", "team": "cloud", "shard": shard},
+                 "annotations": {"summary": "The queue gained 12 failed jobs."}}
+                for shard in ("1", "2")
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert "- The queue gained 12 failed jobs. — shard: `1`" in lines
+    assert "- The queue gained 12 failed jobs. — shard: `2`" in lines
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_summary_carries_a_label_even_wrapped_in_punctuation(integration):
+    """The word the sentence says arrives fenced in backticks or trailed by a period, and is still that word."""
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {"alertname": "Queue has failed jobs"},
+            "commonAnnotations": {},
+            "alerts": [
+                {"status": "firing",
+                 "labels": {"alertname": "Queue has failed jobs", "service_name": "builds",
+                            "k8s_cluster_name": "cloud-fra1-prod"},
+                 "annotations": {"summary": "The `builds` queue failed on cloud-fra1-prod."}},
+                {"status": "firing",
+                 "labels": {"alertname": "Queue has failed jobs", "service_name": "domains",
+                            "k8s_cluster_name": "cloud-syd1-prod"},
+                 "annotations": {"summary": "The `domains` queue failed on cloud-syd1-prod."}},
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    # `builds` sits in backticks and cloud-fra1-prod before a period; the sentence carries both, so no label
+    # is appended to it.
+    assert "- The `builds` queue failed on cloud-fra1-prod." in lines
+    assert "- The `domains` queue failed on cloud-syd1-prod." in lines
+    assert not any("service_name:" in line or "k8s_cluster_name:" in line for line in lines)
 
 
 @pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])

--- a/engine/apps/discord/tests/test_alert_rendering.py
+++ b/engine/apps/discord/tests/test_alert_rendering.py
@@ -820,9 +820,38 @@ def test_an_instance_line_does_not_repeat_what_its_summary_already_says(integrat
 def test_a_summary_carries_a_label_as_a_word_and_not_as_a_syllable(integration):
     """A sentence carries a label when it says it as a word of its own, not when the characters happen to occur.
 
-    Matched anywhere in the sentence, `shard: 1` was read into "12 jobs" and dropped, and with every alert
-    written the same sentence the lines collapsed to one — the very defect naming instances was meant to fix,
-    reachable again through any label short enough to hide inside a number.
+    Matched anywhere in the sentence, `shard: 1` was read into "12 jobs" and dropped — and a label dropped is
+    an instance the card no longer tells apart, reachable through any label short enough to hide inside a
+    number.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Queue has failed jobs"},
+            "commonLabels": {"alertname": "Queue has failed jobs", "team": "cloud"},
+            "commonAnnotations": {},
+            "alerts": [
+                {"status": "firing", "labels": {"alertname": "Queue has failed jobs", "team": "cloud", "shard": shard},
+                 "annotations": {"summary": f"The queue gained 1{shard} failed jobs."}}
+                for shard in ("1", "3")
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert "- The queue gained 11 failed jobs. — shard: `1`" in lines
+    assert "- The queue gained 13 failed jobs. — shard: `3`" in lines
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_a_lone_varying_label_gathers_onto_one_line(integration):
+    """One label alone telling the instances apart gathers onto one line.
+
+    A sentence every instance says is the group's summary, whichever field the sender put it in, so it is said
+    once at the top. What is left telling the instances apart is one label, and a list of lines saying nothing
+    but `shard: 1` and `shard: 2` is a worse way to write `shard: 1, 2`.
     """
     rendered = apply_jinja_template(
         import_module(f"config_integrations.{integration}").discord_message,
@@ -841,8 +870,39 @@ def test_a_summary_carries_a_label_as_a_word_and_not_as_a_syllable(integration):
     )
     lines = rendered.splitlines()
 
-    assert "- The queue gained 12 failed jobs. — shard: `1`" in lines
-    assert "- The queue gained 12 failed jobs. — shard: `2`" in lines
+    assert "**Summaries**" not in lines
+    assert "- shard: `1`, `2`" in lines
+    assert rendered.count("The queue gained 12 failed jobs.") == 1
+    assert lines[0] == "The queue gained 12 failed jobs."
+
+
+@pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])
+def test_two_varying_labels_stay_a_line_per_instance(integration):
+    """Two or more keys stay a line per instance, because which value came with which is the information.
+
+    Gathered per key, `region: fra, syd` and `node: node-1, node-2` no longer say which node is in which
+    region. The shared sentence is still said once at the top rather than on every line.
+    """
+    rendered = apply_jinja_template(
+        import_module(f"config_integrations.{integration}").discord_message,
+        payload={
+            "groupLabels": {"alertname": "Disk filling"},
+            "commonLabels": {"alertname": "Disk filling", "team": "cloud"},
+            "commonAnnotations": {},
+            "alerts": [
+                _disk_alert("fra", "node-1", "Disk is nearly full."),
+                _disk_alert("syd", "node-2", "Disk is nearly full."),
+            ],
+        },
+        source_link="",
+        integration_name="Grafana Alerting",
+    )
+    lines = rendered.splitlines()
+
+    assert lines[0] == "Disk is nearly full."
+    assert rendered.count("Disk is nearly full.") == 1
+    assert "- region: `fra`, instance: `node-1`" in lines
+    assert "- region: `syd`, instance: `node-2`" in lines
 
 
 @pytest.mark.parametrize("integration", ["alertmanager", "grafana_alerting"])

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -255,12 +255,18 @@ discord_message = """\
 {% else -%}
 {% set prose = "" -%}
 {% endif -%}
+{# "Carries" means says as a word of its own: matching anywhere in the sentence read `shard: 1` into "12 jobs"
+   and dropped the one label telling two shards apart. -#}
+{% set carried = [] -%}
+{% for token in prose.split() -%}
+{% set _ = carried.append(token | trim("`.,:;!?()[]{}" ~ '"' ~ "'")) -%}
+{% endfor -%}
 {% set apart = [] -%}
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
    and agreed.get(key) != value
-   and (value | string) not in prose -%}
+   and (value | string) not in carried -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
 {% if prose and apart -%}

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -266,24 +266,29 @@ discord_message = """\
 {% set instances = [] -%}
 {% for alert in payload.get("alerts", []) -%}
 {% set own = alert.get("annotations", {}).get("summary") -%}
-{% if own -%}
-{% set _ = instances.append((own | string).split() | join(" ")) -%}
-{% else -%}
 {% set apart = [] -%}
+{% if not own -%}
 {% for key, value in alert.get("labels", {}).items()
    if key not in ["alertname", "severity"]
    and not key.startswith("__")
    and commonLabels.get(key) != value -%}
 {% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
 {% endfor -%}
-{% if apart -%}
-{% set _ = instances.append(apart | join(", ")) -%}
 {% endif -%}
+{% if own -%}
+{% set entry = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set entry = apart | join(", ") -%}
+{% endif -%}
+{# Said once: not the summary the card has already printed above, and not another instance's line. -#}
+{% if entry and entry != summary and entry not in instances -%}
+{% set _ = instances.append(entry) -%}
 {% endif -%}
 {% endfor -%}
 
-{# A group of one already says everything it has in the lines above. -#}
-{% if instances | length > 1 %}
+{# A group of one says everything it has in the lines above. A group of many says what is in it, even when only
+   one of them turned out to carry anything of its own: that one line is the only thing naming what failed. -#}
+{% if instances and (payload.get("alerts", []) | length) > 1 %}
 **Instances**
 {% for entry in instances[:20] -%}
 - {{ entry }}

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -207,47 +207,76 @@ web_image_url = None
 discord_title = web_title
 
 discord_message = """\
-{% macro bullet(key, value) -%}
+{# A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels
+   and annotations. `groupLabels`, `commonLabels` and `commonAnnotations` are views Alertmanager derives from
+   them — the part the instances agree on. The legacy integration sends no `alerts` and puts a single instance's
+   labels and annotations at the top level, so it is read here as a group of one and nothing below this block has
+   to know which shape arrived.
+
+   A card says the agreed part once, and names the instances when there is more than one, because what sets them
+   apart is exactly what the agreed part cannot carry. -#}
+{% macro pair(key, value) -%}
 {% set flat = (value | string).split() | join(" ") -%}
 {% if "`" in flat -%}
-- {{ key }}: {{ flat }}
+{{ key }}: {{ flat }}
 {%- else -%}
-- {{ key }}: `{{ flat }}`
+{{ key }}: `{{ flat }}`
 {%- endif -%}
 {% endmacro -%}
-{% set groupLabels = payload.get("groupLabels", {}) -%}
-{% set commonLabels = payload.get("commonLabels", {}) -%}
-{# The legacy alertmanager integration puts labels and annotations at the top level instead. -#}
-{% set annotations = payload.get("commonAnnotations", {}) if payload.get("commonAnnotations") else payload.get("annotations", {}) -%}
-{% set legacyLabels = payload.get("labels", {}) -%}
 
-{# Grafana sends its own identifiers as labels too, wrapped in double underscores the same way. -#}
-{% set said = {} -%}
-{% set labels = [] -%}
-{% for source in [groupLabels, commonLabels, legacyLabels] -%}
+{# alertname titles the card, and severity is its title emoji and its forum tag, so neither is a line on it.
+   Grafana wraps its own identifiers in double underscores and hides them in its own UI. -#}
+{% set said_elsewhere = ["alertname", "severity"] -%}
+{% set instances = payload.get("alerts") or [{"labels": payload.get("labels", {}), "annotations": payload.get("annotations", {})}] -%}
+{% set agreed = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
+{% set shared = {} -%}
+{% for source in [payload.get("groupLabels", {}), payload.get("commonLabels", {}), payload.get("labels", {})] -%}
 {% for key, value in source.items()
-   if key not in ["alertname", "severity"]
-   and not key.startswith("__")
-   and said.get(key) != value -%}
-{% set _ = said.update({key: value}) -%}
-{% set _ = labels.append(bullet(key, value)) -%}
+   if key not in shared
+   and key not in said_elsewhere
+   and not key.startswith("__") -%}
+{% set _ = shared.update({key: value}) -%}
 {% endfor -%}
 {% endfor -%}
 
-{# The dashboard and runbook links are buttons on the card, so they are not repeated as lines to copy out of.
-   `value_string` is the long form of `values`, dropped only when there is a `values` to read instead of it. -#}
+{% set summary = agreed.get("summary") -%}
+{% set description = agreed.get("description") -%}
+
+{# An instance says its own summary when its rule wrote one, because a sentence naming the thing reads better
+   than the labels the sentence was built from. Otherwise it names itself by the labels the group does not
+   share. Either way it is said once: not the summary already above, and not a line another instance has said. -#}
+{% set listed = [] -%}
+{% for instance in instances -%}
+{% set own = instance.get("annotations", {}).get("summary") -%}
+{% set apart = [] -%}
+{% for key, value in instance.get("labels", {}).items()
+   if key not in said_elsewhere
+   and not key.startswith("__")
+   and shared.get(key) != value -%}
+{% set _ = apart.append(pair(key, value) | trim) -%}
+{% endfor -%}
+{% if own -%}
+{% set line = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set line = apart | join(", ") -%}
+{% endif -%}
+{% if line and line != summary and line not in listed -%}
+{% set _ = listed.append(line) -%}
+{% endif -%}
+{% endfor -%}
+
+{# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
+   of `values`, dropped only when there is a `values` to read instead of it. -#}
 {% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
+{% set spoken = spoken + ["value_string"] if agreed.get("values") else spoken -%}
 {% set notes = [] -%}
-{% for key, value in annotations.items()
+{% for key, value in agreed.items()
    if key not in spoken
    and not key.startswith("__")
-   and said.get(key) != value -%}
-{% set _ = notes.append(bullet(key, value)) -%}
+   and shared.get(key) != value -%}
+{% set _ = notes.append(pair(key, value) | trim) -%}
 {% endfor -%}
 
-{% set summary = annotations.get("summary") -%}
-{% set description = annotations.get("description") -%}
 {% if summary -%}
 {{ summary }}
 {% endif -%}
@@ -259,64 +288,37 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
-{# One group can hold an instance per worker, region or host, and the route decides what they share: a label that
-   differs between them is in neither commonLabels nor commonAnnotations, and neither is a summary written from
-   it. Grouped by alertname alone, a card would name none of the things that are actually failing, so each
-   instance says itself — by its own summary, or by the labels that set it apart from the group. -#}
-{% set instances = [] -%}
-{% for alert in payload.get("alerts", []) -%}
-{% set own = alert.get("annotations", {}).get("summary") -%}
-{% set apart = [] -%}
-{% if not own -%}
-{% for key, value in alert.get("labels", {}).items()
-   if key not in ["alertname", "severity"]
-   and not key.startswith("__")
-   and commonLabels.get(key) != value -%}
-{% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
-{% endfor -%}
-{% endif -%}
-{% if own -%}
-{% set entry = (own | string).split() | join(" ") -%}
-{% else -%}
-{% set entry = apart | join(", ") -%}
-{% endif -%}
-{# Said once: not the summary the card has already printed above, and not another instance's line. -#}
-{% if entry and entry != summary and entry not in instances -%}
-{% set _ = instances.append(entry) -%}
-{% endif -%}
-{% endfor -%}
-
-{# A group of one says everything it has in the lines above. A group of many says what is in it, even when only
-   one of them turned out to carry anything of its own: that one line is the only thing naming what failed. -#}
-{% if instances and (payload.get("alerts", []) | length) > 1 %}
+{# A group of one has said everything it has above. A group of many says what is in it, even when only one of
+   them turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
+{% if listed and (instances | length) > 1 %}
 **Instances**
-{% for entry in instances[:20] -%}
-- {{ entry }}
+{% for line in listed[:20] -%}
+- {{ line }}
 {% endfor -%}
-{% if instances | length > 20 -%}
-- and {{ instances | length - 20 }} more
+{% if listed | length > 20 -%}
+- and {{ listed | length - 20 }} more
 {% endif -%}
 {% endif -%}
 
-{% if labels %}
+{% if shared %}
 **Labels**
-{% for entry in labels -%}
-{{ entry }}
+{% for key, value in shared.items() -%}
+- {{ pair(key, value) | trim }}
 {% endfor -%}
 {% endif -%}
 
 {% if notes %}
 **Annotations**
-{% for entry in notes -%}
-{{ entry }}
+{% for note in notes -%}
+- {{ note }}
 {% endfor -%}
 {% endif -%}
 
-{% if annotations.get("runbook_url") -%}
-[:book: Runbook]({{ annotations.runbook_url }})
+{% if agreed.get("runbook_url") -%}
+[:book: Runbook]({{ agreed.runbook_url }})
 {% endif -%}
-{% if annotations.get("runbook_url_internal") -%}
-[:closed_book: Runbook (internal)]({{ annotations.runbook_url_internal }})
+{% if agreed.get("runbook_url_internal") -%}
+[:closed_book: Runbook (internal)]({{ agreed.runbook_url_internal }})
 {% endif -%}
 """  # noqa
 

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -242,25 +242,35 @@ discord_message = """\
 {% set summary = agreed.get("summary") -%}
 {% set description = agreed.get("description") -%}
 
-{# An instance says its own summary when its rule wrote one, because a sentence naming the thing reads better
-   than the labels the sentence was built from. Otherwise it names itself by the labels the group does not
-   share. Either way it is said once: not the summary already above, and not a line another instance has said. -#}
+{# What identifies an instance is the labels the group does not share; a summary is prose that usually names
+   them and is not required to. So an instance says its own summary when its rule wrote one that is not already
+   the summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
+   every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
 {% set listed = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
+{% if own and own != summary -%}
+{% set prose = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set prose = "" -%}
+{% endif -%}
 {% set apart = [] -%}
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
-   and shared.get(key) != value -%}
+   and shared.get(key) != value
+   and (value | string) not in prose -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
-{% if own -%}
-{% set line = (own | string).split() | join(" ") -%}
+{% if prose and apart -%}
+{% set line = prose ~ " — " ~ (apart | join(", ")) -%}
+{% elif prose -%}
+{% set line = prose -%}
 {% else -%}
 {% set line = apart | join(", ") -%}
 {% endif -%}
-{% if line and line != summary and line not in listed -%}
+{# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
+{% if line and line not in listed -%}
 {% set _ = listed.append(line) -%}
 {% endif -%}
 {% endfor -%}

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -241,6 +241,17 @@ discord_message = """\
 {% endfor -%}
 
 {% set summary = annotations.get("summary") -%}
+{# A sentence every instance says is the group's summary, whichever field the sender put it in: repeated on a
+   line per instance it reads as a list saying one thing. -#}
+{% if not summary and (instances | length) > 1 -%}
+{% set owns = [] -%}
+{% for instance in instances -%}
+{% set _ = owns.append(instance.get("annotations", {}).get("summary")) -%}
+{% endfor -%}
+{% if owns[0] and owns | unique | list | length == 1 -%}
+{% set summary = owns[0] -%}
+{% endif -%}
+{% endif -%}
 {% set description = annotations.get("description") -%}
 
 {# What identifies an instance is the labels the group does not share; a summary is prose that usually names them
@@ -248,10 +259,14 @@ discord_message = """\
    summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
    every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
 {% set summaries = [] -%}
+{% set apart_keys = [] -%}
+{% set apart_values = [] -%}
+{% set prose_lines = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
 {% if own and own != summary -%}
 {% set prose = (own | string).split() | join(" ") -%}
+{% set _ = prose_lines.append(prose) -%}
 {% else -%}
 {% set prose = "" -%}
 {% endif -%}
@@ -268,6 +283,13 @@ discord_message = """\
    and agreed.get(key) != value
    and (value | string) not in carried -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
+{% if key not in apart_keys -%}
+{% set _ = apart_keys.append(key) -%}
+{% endif -%}
+{% set flat = (value | string).split() | join(" ") -%}
+{% if flat not in apart_values -%}
+{% set _ = apart_values.append(flat) -%}
+{% endif -%}
 {% endfor -%}
 {% if prose and apart -%}
 {% set line = prose ~ " — " ~ (apart | join(", ")) -%}
@@ -281,6 +303,11 @@ discord_message = """\
 {% set _ = summaries.append(line) -%}
 {% endif -%}
 {% endfor -%}
+
+{# One label alone telling the instances apart gathers onto one line: a list of lines saying nothing but
+   `shard: 1` and `shard: 2` is a worse way to write `shard: 1, 2`. Two or more keys stay a line per
+   instance, because which value came with which is the information. -#}
+{% set gathered = (instances | length) > 1 and apart_keys | length == 1 and not prose_lines -%}
 
 {# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
    of `values`, dropped only when there is a `values` to read instead of it. -#}
@@ -307,7 +334,7 @@ discord_message = """\
 
 {# A group of one has said its summary above. A group of many says one per instance, even when only one of them
    turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
-{% if summaries and (instances | length) > 1 %}
+{% if summaries and not gathered and (instances | length) > 1 %}
 **Summaries**
 {% for line in summaries[:20] -%}
 - {{ line }}
@@ -327,11 +354,17 @@ discord_message = """\
 {% endfor -%}
 {% endif -%}
 
-{% if agreed.keys() | reject("in", grouped_by) | list %}
+{% if agreed.keys() | reject("in", grouped_by) | list or gathered %}
 **Labels**
 {% for key, value in agreed.items() if key not in grouped_by -%}
 - {{ pair(key, value) | trim }}
 {% endfor -%}
+{% if gathered -%}
+- {{ apart_keys[0] }}: {% for value in apart_values[:20] -%}
+{{ value if "`" in value else "`" ~ value ~ "`" }}{{ ", " if not loop.last }}
+{%- endfor -%}
+{{ " and " ~ (apart_values | length - 20) ~ " more" if apart_values | length > 20 }}
+{% endif -%}
 {% endif -%}
 
 {% if notes %}

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -254,21 +254,23 @@ discord_message = """\
 {% endif -%}
 {% set description = annotations.get("description") -%}
 
-{# What identifies an instance is the labels the group does not share; a summary is prose that usually names them
-   and is not required to. So an instance says its own summary when its rule wrote one that is not already the
-   summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
-   every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
-{% set summaries = [] -%}
-{% set apart_keys = [] -%}
-{% set apart_values = [] -%}
+{# What identifies an instance is its own summary and the labels the group does not share. A summary is prose:
+   it usually names its instance and is not required to, so the labels the sentence does not carry are kept too —
+   gathered by key under Labels rather than trailing the sentence, because prose reads as prose and
+   `fra`, `syd` reads as one fact about the group. -#}
 {% set prose_lines = [] -%}
+{% set tuple_lines = [] -%}
+{% set varied = {} -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
 {% if own and own != summary -%}
 {% set prose = (own | string).split() | join(" ") -%}
-{% set _ = prose_lines.append(prose) -%}
 {% else -%}
 {% set prose = "" -%}
+{% endif -%}
+{# Two instances that wrote the same sentence read as one line; their labels below still count both. -#}
+{% if prose and prose not in prose_lines -%}
+{% set _ = prose_lines.append(prose) -%}
 {% endif -%}
 {# "Carries" means says as a word of its own: matching anywhere in the sentence read `shard: 1` into "12 jobs"
    and dropped the one label telling two shards apart. -#}
@@ -283,31 +285,25 @@ discord_message = """\
    and agreed.get(key) != value
    and (value | string) not in carried -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
-{% if key not in apart_keys -%}
-{% set _ = apart_keys.append(key) -%}
-{% endif -%}
 {% set flat = (value | string).split() | join(" ") -%}
-{% if flat not in apart_values -%}
-{% set _ = apart_values.append(flat) -%}
+{% if flat not in varied.get(key, []) -%}
+{% set _ = varied.update({key: varied.get(key, []) + [flat]}) -%}
 {% endif -%}
 {% endfor -%}
-{% if prose and apart -%}
-{% set line = prose ~ " — " ~ (apart | join(", ")) -%}
-{% elif prose -%}
-{% set line = prose -%}
-{% else -%}
-{% set line = apart | join(", ") -%}
-{% endif -%}
-{# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
-{% if line and line not in summaries -%}
-{% set _ = summaries.append(line) -%}
+{% if apart and (apart | join(", ")) not in tuple_lines -%}
+{% set _ = tuple_lines.append(apart | join(", ")) -%}
 {% endif -%}
 {% endfor -%}
 
-{# One label alone telling the instances apart gathers onto one line: a list of lines saying nothing but
-   `shard: 1` and `shard: 2` is a worse way to write `shard: 1, 2`. Two or more keys stay a line per
-   instance, because which value came with which is the information. -#}
-{% set gathered = (instances | length) > 1 and apart_keys | length == 1 and not prose_lines -%}
+{# Which value came with which is information the gathering loses, and when nothing else names the instances —
+   no prose, two or more keys — a line per instance keeps the pairing. Otherwise labels gather by key: prose
+   names its own instance, and one key has nothing to pair. -#}
+{% if not prose_lines and varied | length > 1 -%}
+{% set summaries = tuple_lines -%}
+{% set varied = {} -%}
+{% else -%}
+{% set summaries = prose_lines -%}
+{% endif -%}
 
 {# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
    of `values`, dropped only when there is a `values` to read instead of it. -#}
@@ -334,7 +330,7 @@ discord_message = """\
 
 {# A group of one has said its summary above. A group of many says one per instance, even when only one of them
    turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
-{% if summaries and not gathered and (instances | length) > 1 %}
+{% if summaries and (instances | length) > 1 %}
 **Summaries**
 {% for line in summaries[:20] -%}
 - {{ line }}
@@ -354,17 +350,17 @@ discord_message = """\
 {% endfor -%}
 {% endif -%}
 
-{% if agreed.keys() | reject("in", grouped_by) | list or gathered %}
+{% if agreed.keys() | reject("in", grouped_by) | list or varied %}
 **Labels**
 {% for key, value in agreed.items() if key not in grouped_by -%}
 - {{ pair(key, value) | trim }}
 {% endfor -%}
-{% if gathered -%}
-- {{ apart_keys[0] }}: {% for value in apart_values[:20] -%}
+{% for key, values in varied.items() -%}
+- {{ key }}: {% for value in values[:20] -%}
 {{ value if "`" in value else "`" ~ value ~ "`" }}{{ ", " if not loop.last }}
 {%- endfor -%}
-{{ " and " ~ (apart_values | length - 20) ~ " more" if apart_values | length > 20 }}
-{% endif -%}
+{{ " and " ~ (values | length - 20) ~ " more" if values | length > 20 }}
+{% endfor -%}
 {% endif -%}
 
 {% if notes %}

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -208,13 +208,13 @@ discord_title = web_title
 
 discord_message = """\
 {# A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels
-   and annotations. `groupLabels`, `commonLabels` and `commonAnnotations` are views Alertmanager derives from
-   them — the part the instances agree on. The legacy integration sends no `alerts` and puts a single instance's
-   labels and annotations at the top level, so it is read here as a group of one and nothing below this block has
-   to know which shape arrived.
+   and annotations. Everything else is a view Alertmanager derives from them — `groupLabels` is what the route
+   grouped by, `commonLabels` and `commonAnnotations` are what the instances happen to agree on. The legacy
+   integration sends no `alerts` and puts a single instance's labels and annotations at the top level, so it is
+   read here as a group of one and nothing after this block has to know which shape arrived.
 
-   A card says the agreed part once, and names the instances when there is more than one, because what sets them
-   apart is exactly what the agreed part cannot carry. -#}
+   A card says the agreed part once, and lists a summary per instance when it holds more than one, because what
+   sets the instances apart is exactly what the agreed part cannot carry. -#}
 {% macro pair(key, value) -%}
 {% set flat = (value | string).split() | join(" ") -%}
 {% if "`" in flat -%}
@@ -228,25 +228,26 @@ discord_message = """\
    Grafana wraps its own identifiers in double underscores and hides them in its own UI. -#}
 {% set said_elsewhere = ["alertname", "severity"] -%}
 {% set instances = payload.get("alerts") or [{"labels": payload.get("labels", {}), "annotations": payload.get("annotations", {})}] -%}
-{% set agreed = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
-{% set shared = {} -%}
-{% for source in [payload.get("groupLabels", {}), payload.get("commonLabels", {}), payload.get("labels", {})] -%}
+{% set grouped_by = payload.get("groupLabels", {}) -%}
+{% set annotations = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
+{% set agreed = {} -%}
+{% for source in [grouped_by, payload.get("commonLabels", {}), payload.get("labels", {})] -%}
 {% for key, value in source.items()
-   if key not in shared
+   if key not in agreed
    and key not in said_elsewhere
    and not key.startswith("__") -%}
-{% set _ = shared.update({key: value}) -%}
+{% set _ = agreed.update({key: value}) -%}
 {% endfor -%}
 {% endfor -%}
 
-{% set summary = agreed.get("summary") -%}
-{% set description = agreed.get("description") -%}
+{% set summary = annotations.get("summary") -%}
+{% set description = annotations.get("description") -%}
 
-{# What identifies an instance is the labels the group does not share; a summary is prose that usually names
-   them and is not required to. So an instance says its own summary when its rule wrote one that is not already
-   the summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
+{# What identifies an instance is the labels the group does not share; a summary is prose that usually names them
+   and is not required to. So an instance says its own summary when its rule wrote one that is not already the
+   summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
    every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
-{% set listed = [] -%}
+{% set summaries = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
 {% if own and own != summary -%}
@@ -258,7 +259,7 @@ discord_message = """\
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
-   and shared.get(key) != value
+   and agreed.get(key) != value
    and (value | string) not in prose -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
@@ -270,20 +271,20 @@ discord_message = """\
 {% set line = apart | join(", ") -%}
 {% endif -%}
 {# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
-{% if line and line not in listed -%}
-{% set _ = listed.append(line) -%}
+{% if line and line not in summaries -%}
+{% set _ = summaries.append(line) -%}
 {% endif -%}
 {% endfor -%}
 
 {# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
    of `values`, dropped only when there is a `values` to read instead of it. -#}
 {% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if agreed.get("values") else spoken -%}
+{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
 {% set notes = [] -%}
-{% for key, value in agreed.items()
+{% for key, value in annotations.items()
    if key not in spoken
    and not key.startswith("__")
-   and shared.get(key) != value -%}
+   and agreed.get(key) != value -%}
 {% set _ = notes.append(pair(key, value) | trim) -%}
 {% endfor -%}
 
@@ -298,21 +299,31 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
-{# A group of one has said everything it has above. A group of many says what is in it, even when only one of
-   them turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
-{% if listed and (instances | length) > 1 %}
-**Instances**
-{% for line in listed[:20] -%}
+{# A group of one has said its summary above. A group of many says one per instance, even when only one of them
+   turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
+{% if summaries and (instances | length) > 1 %}
+**Summaries**
+{% for line in summaries[:20] -%}
 - {{ line }}
 {% endfor -%}
-{% if listed | length > 20 -%}
-- and {{ listed | length - 20 }} more
+{% if summaries | length > 20 -%}
+- and {{ summaries | length - 20 }} more
 {% endif -%}
 {% endif -%}
 
-{% if shared %}
+{# What the route grouped by, and then what the instances turned out to share beyond it. Kept apart because they
+   answer different questions: the first is why these alerts arrived as one card, the second is what they have in
+   common once they had. -#}
+{% if agreed.keys() | select("in", grouped_by) | list %}
+**Group**
+{% for key, value in agreed.items() if key in grouped_by -%}
+- {{ pair(key, value) | trim }}
+{% endfor -%}
+{% endif -%}
+
+{% if agreed.keys() | reject("in", grouped_by) | list %}
 **Labels**
-{% for key, value in shared.items() -%}
+{% for key, value in agreed.items() if key not in grouped_by -%}
 - {{ pair(key, value) | trim }}
 {% endfor -%}
 {% endif -%}
@@ -324,11 +335,11 @@ discord_message = """\
 {% endfor -%}
 {% endif -%}
 
-{% if agreed.get("runbook_url") -%}
-[:book: Runbook]({{ agreed.runbook_url }})
+{% if annotations.get("runbook_url") -%}
+[:book: Runbook]({{ annotations.runbook_url }})
 {% endif -%}
-{% if agreed.get("runbook_url_internal") -%}
-[:closed_book: Runbook (internal)]({{ agreed.runbook_url_internal }})
+{% if annotations.get("runbook_url_internal") -%}
+[:closed_book: Runbook (internal)]({{ annotations.runbook_url_internal }})
 {% endif -%}
 """  # noqa
 

--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -259,6 +259,40 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
+{# One group can hold an instance per worker, region or host, and the route decides what they share: a label that
+   differs between them is in neither commonLabels nor commonAnnotations, and neither is a summary written from
+   it. Grouped by alertname alone, a card would name none of the things that are actually failing, so each
+   instance says itself — by its own summary, or by the labels that set it apart from the group. -#}
+{% set instances = [] -%}
+{% for alert in payload.get("alerts", []) -%}
+{% set own = alert.get("annotations", {}).get("summary") -%}
+{% if own -%}
+{% set _ = instances.append((own | string).split() | join(" ")) -%}
+{% else -%}
+{% set apart = [] -%}
+{% for key, value in alert.get("labels", {}).items()
+   if key not in ["alertname", "severity"]
+   and not key.startswith("__")
+   and commonLabels.get(key) != value -%}
+{% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
+{% endfor -%}
+{% if apart -%}
+{% set _ = instances.append(apart | join(", ")) -%}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
+
+{# A group of one already says everything it has in the lines above. -#}
+{% if instances | length > 1 %}
+**Instances**
+{% for entry in instances[:20] -%}
+- {{ entry }}
+{% endfor -%}
+{% if instances | length > 20 -%}
+- and {{ instances | length - 20 }} more
+{% endif -%}
+{% endif -%}
+
 {% if labels %}
 **Labels**
 {% for entry in labels -%}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -268,24 +268,29 @@ discord_message = """\
 {% set instances = [] -%}
 {% for alert in payload.get("alerts", []) -%}
 {% set own = alert.get("annotations", {}).get("summary") -%}
-{% if own -%}
-{% set _ = instances.append((own | string).split() | join(" ")) -%}
-{% else -%}
 {% set apart = [] -%}
+{% if not own -%}
 {% for key, value in alert.get("labels", {}).items()
    if key not in ["alertname", "severity"]
    and not key.startswith("__")
    and commonLabels.get(key) != value -%}
 {% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
 {% endfor -%}
-{% if apart -%}
-{% set _ = instances.append(apart | join(", ")) -%}
 {% endif -%}
+{% if own -%}
+{% set entry = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set entry = apart | join(", ") -%}
+{% endif -%}
+{# Said once: not the summary the card has already printed above, and not another instance's line. -#}
+{% if entry and entry != summary and entry not in instances -%}
+{% set _ = instances.append(entry) -%}
 {% endif -%}
 {% endfor -%}
 
-{# A group of one already says everything it has in the lines above. -#}
-{% if instances | length > 1 %}
+{# A group of one says everything it has in the lines above. A group of many says what is in it, even when only
+   one of them turned out to carry anything of its own: that one line is the only thing naming what failed. -#}
+{% if instances and (payload.get("alerts", []) | length) > 1 %}
 **Instances**
 {% for entry in instances[:20] -%}
 - {{ entry }}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -244,25 +244,35 @@ discord_message = """\
 {% set summary = agreed.get("summary") -%}
 {% set description = agreed.get("description") -%}
 
-{# An instance says its own summary when its rule wrote one, because a sentence naming the thing reads better
-   than the labels the sentence was built from. Otherwise it names itself by the labels the group does not
-   share. Either way it is said once: not the summary already above, and not a line another instance has said. -#}
+{# What identifies an instance is the labels the group does not share; a summary is prose that usually names
+   them and is not required to. So an instance says its own summary when its rule wrote one that is not already
+   the summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
+   every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
 {% set listed = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
+{% if own and own != summary -%}
+{% set prose = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set prose = "" -%}
+{% endif -%}
 {% set apart = [] -%}
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
-   and shared.get(key) != value -%}
+   and shared.get(key) != value
+   and (value | string) not in prose -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
-{% if own -%}
-{% set line = (own | string).split() | join(" ") -%}
+{% if prose and apart -%}
+{% set line = prose ~ " — " ~ (apart | join(", ")) -%}
+{% elif prose -%}
+{% set line = prose -%}
 {% else -%}
 {% set line = apart | join(", ") -%}
 {% endif -%}
-{% if line and line != summary and line not in listed -%}
+{# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
+{% if line and line not in listed -%}
 {% set _ = listed.append(line) -%}
 {% endif -%}
 {% endfor -%}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -209,47 +209,76 @@ web_image_url = None
 discord_title = web_title
 
 discord_message = """\
-{% macro bullet(key, value) -%}
+{# A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels
+   and annotations. `groupLabels`, `commonLabels` and `commonAnnotations` are views Alertmanager derives from
+   them — the part the instances agree on. The legacy integration sends no `alerts` and puts a single instance's
+   labels and annotations at the top level, so it is read here as a group of one and nothing below this block has
+   to know which shape arrived.
+
+   A card says the agreed part once, and names the instances when there is more than one, because what sets them
+   apart is exactly what the agreed part cannot carry. -#}
+{% macro pair(key, value) -%}
 {% set flat = (value | string).split() | join(" ") -%}
 {% if "`" in flat -%}
-- {{ key }}: {{ flat }}
+{{ key }}: {{ flat }}
 {%- else -%}
-- {{ key }}: `{{ flat }}`
+{{ key }}: `{{ flat }}`
 {%- endif -%}
 {% endmacro -%}
-{% set groupLabels = payload.get("groupLabels", {}) -%}
-{% set commonLabels = payload.get("commonLabels", {}) -%}
-{# The legacy alertmanager integration puts labels and annotations at the top level instead. -#}
-{% set annotations = payload.get("commonAnnotations", {}) if payload.get("commonAnnotations") else payload.get("annotations", {}) -%}
-{% set legacyLabels = payload.get("labels", {}) -%}
 
-{# Grafana sends its own identifiers as labels too, wrapped in double underscores the same way. -#}
-{% set said = {} -%}
-{% set labels = [] -%}
-{% for source in [groupLabels, commonLabels, legacyLabels] -%}
+{# alertname titles the card, and severity is its title emoji and its forum tag, so neither is a line on it.
+   Grafana wraps its own identifiers in double underscores and hides them in its own UI. -#}
+{% set said_elsewhere = ["alertname", "severity"] -%}
+{% set instances = payload.get("alerts") or [{"labels": payload.get("labels", {}), "annotations": payload.get("annotations", {})}] -%}
+{% set agreed = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
+{% set shared = {} -%}
+{% for source in [payload.get("groupLabels", {}), payload.get("commonLabels", {}), payload.get("labels", {})] -%}
 {% for key, value in source.items()
-   if key not in ["alertname", "severity"]
-   and not key.startswith("__")
-   and said.get(key) != value -%}
-{% set _ = said.update({key: value}) -%}
-{% set _ = labels.append(bullet(key, value)) -%}
+   if key not in shared
+   and key not in said_elsewhere
+   and not key.startswith("__") -%}
+{% set _ = shared.update({key: value}) -%}
 {% endfor -%}
 {% endfor -%}
 
-{# The dashboard and runbook links are buttons on the card, so they are not repeated as lines to copy out of.
-   `value_string` is the long form of `values`, dropped only when there is a `values` to read instead of it. -#}
+{% set summary = agreed.get("summary") -%}
+{% set description = agreed.get("description") -%}
+
+{# An instance says its own summary when its rule wrote one, because a sentence naming the thing reads better
+   than the labels the sentence was built from. Otherwise it names itself by the labels the group does not
+   share. Either way it is said once: not the summary already above, and not a line another instance has said. -#}
+{% set listed = [] -%}
+{% for instance in instances -%}
+{% set own = instance.get("annotations", {}).get("summary") -%}
+{% set apart = [] -%}
+{% for key, value in instance.get("labels", {}).items()
+   if key not in said_elsewhere
+   and not key.startswith("__")
+   and shared.get(key) != value -%}
+{% set _ = apart.append(pair(key, value) | trim) -%}
+{% endfor -%}
+{% if own -%}
+{% set line = (own | string).split() | join(" ") -%}
+{% else -%}
+{% set line = apart | join(", ") -%}
+{% endif -%}
+{% if line and line != summary and line not in listed -%}
+{% set _ = listed.append(line) -%}
+{% endif -%}
+{% endfor -%}
+
+{# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
+   of `values`, dropped only when there is a `values` to read instead of it. -#}
 {% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
+{% set spoken = spoken + ["value_string"] if agreed.get("values") else spoken -%}
 {% set notes = [] -%}
-{% for key, value in annotations.items()
+{% for key, value in agreed.items()
    if key not in spoken
    and not key.startswith("__")
-   and said.get(key) != value -%}
-{% set _ = notes.append(bullet(key, value)) -%}
+   and shared.get(key) != value -%}
+{% set _ = notes.append(pair(key, value) | trim) -%}
 {% endfor -%}
 
-{% set summary = annotations.get("summary") -%}
-{% set description = annotations.get("description") -%}
 {% if summary -%}
 {{ summary }}
 {% endif -%}
@@ -261,64 +290,37 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
-{# One group can hold an instance per worker, region or host, and the route decides what they share: a label that
-   differs between them is in neither commonLabels nor commonAnnotations, and neither is a summary written from
-   it. Grouped by alertname alone, a card would name none of the things that are actually failing, so each
-   instance says itself — by its own summary, or by the labels that set it apart from the group. -#}
-{% set instances = [] -%}
-{% for alert in payload.get("alerts", []) -%}
-{% set own = alert.get("annotations", {}).get("summary") -%}
-{% set apart = [] -%}
-{% if not own -%}
-{% for key, value in alert.get("labels", {}).items()
-   if key not in ["alertname", "severity"]
-   and not key.startswith("__")
-   and commonLabels.get(key) != value -%}
-{% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
-{% endfor -%}
-{% endif -%}
-{% if own -%}
-{% set entry = (own | string).split() | join(" ") -%}
-{% else -%}
-{% set entry = apart | join(", ") -%}
-{% endif -%}
-{# Said once: not the summary the card has already printed above, and not another instance's line. -#}
-{% if entry and entry != summary and entry not in instances -%}
-{% set _ = instances.append(entry) -%}
-{% endif -%}
-{% endfor -%}
-
-{# A group of one says everything it has in the lines above. A group of many says what is in it, even when only
-   one of them turned out to carry anything of its own: that one line is the only thing naming what failed. -#}
-{% if instances and (payload.get("alerts", []) | length) > 1 %}
+{# A group of one has said everything it has above. A group of many says what is in it, even when only one of
+   them turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
+{% if listed and (instances | length) > 1 %}
 **Instances**
-{% for entry in instances[:20] -%}
-- {{ entry }}
+{% for line in listed[:20] -%}
+- {{ line }}
 {% endfor -%}
-{% if instances | length > 20 -%}
-- and {{ instances | length - 20 }} more
+{% if listed | length > 20 -%}
+- and {{ listed | length - 20 }} more
 {% endif -%}
 {% endif -%}
 
-{% if labels %}
+{% if shared %}
 **Labels**
-{% for entry in labels -%}
-{{ entry }}
+{% for key, value in shared.items() -%}
+- {{ pair(key, value) | trim }}
 {% endfor -%}
 {% endif -%}
 
 {% if notes %}
 **Annotations**
-{% for entry in notes -%}
-{{ entry }}
+{% for note in notes -%}
+- {{ note }}
 {% endfor -%}
 {% endif -%}
 
-{% if annotations.get("runbook_url") -%}
-[:book: Runbook]({{ annotations.runbook_url }})
+{% if agreed.get("runbook_url") -%}
+[:book: Runbook]({{ agreed.runbook_url }})
 {% endif -%}
-{% if annotations.get("runbook_url_internal") -%}
-[:closed_book: Runbook (internal)]({{ annotations.runbook_url_internal }})
+{% if agreed.get("runbook_url_internal") -%}
+[:closed_book: Runbook (internal)]({{ agreed.runbook_url_internal }})
 {% endif -%}
 """  # noqa
 

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -243,6 +243,17 @@ discord_message = """\
 {% endfor -%}
 
 {% set summary = annotations.get("summary") -%}
+{# A sentence every instance says is the group's summary, whichever field the sender put it in: repeated on a
+   line per instance it reads as a list saying one thing. -#}
+{% if not summary and (instances | length) > 1 -%}
+{% set owns = [] -%}
+{% for instance in instances -%}
+{% set _ = owns.append(instance.get("annotations", {}).get("summary")) -%}
+{% endfor -%}
+{% if owns[0] and owns | unique | list | length == 1 -%}
+{% set summary = owns[0] -%}
+{% endif -%}
+{% endif -%}
 {% set description = annotations.get("description") -%}
 
 {# What identifies an instance is the labels the group does not share; a summary is prose that usually names them
@@ -250,10 +261,14 @@ discord_message = """\
    summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
    every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
 {% set summaries = [] -%}
+{% set apart_keys = [] -%}
+{% set apart_values = [] -%}
+{% set prose_lines = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
 {% if own and own != summary -%}
 {% set prose = (own | string).split() | join(" ") -%}
+{% set _ = prose_lines.append(prose) -%}
 {% else -%}
 {% set prose = "" -%}
 {% endif -%}
@@ -270,6 +285,13 @@ discord_message = """\
    and agreed.get(key) != value
    and (value | string) not in carried -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
+{% if key not in apart_keys -%}
+{% set _ = apart_keys.append(key) -%}
+{% endif -%}
+{% set flat = (value | string).split() | join(" ") -%}
+{% if flat not in apart_values -%}
+{% set _ = apart_values.append(flat) -%}
+{% endif -%}
 {% endfor -%}
 {% if prose and apart -%}
 {% set line = prose ~ " — " ~ (apart | join(", ")) -%}
@@ -283,6 +305,11 @@ discord_message = """\
 {% set _ = summaries.append(line) -%}
 {% endif -%}
 {% endfor -%}
+
+{# One label alone telling the instances apart gathers onto one line: a list of lines saying nothing but
+   `shard: 1` and `shard: 2` is a worse way to write `shard: 1, 2`. Two or more keys stay a line per
+   instance, because which value came with which is the information. -#}
+{% set gathered = (instances | length) > 1 and apart_keys | length == 1 and not prose_lines -%}
 
 {# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
    of `values`, dropped only when there is a `values` to read instead of it. -#}
@@ -309,7 +336,7 @@ discord_message = """\
 
 {# A group of one has said its summary above. A group of many says one per instance, even when only one of them
    turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
-{% if summaries and (instances | length) > 1 %}
+{% if summaries and not gathered and (instances | length) > 1 %}
 **Summaries**
 {% for line in summaries[:20] -%}
 - {{ line }}
@@ -329,11 +356,17 @@ discord_message = """\
 {% endfor -%}
 {% endif -%}
 
-{% if agreed.keys() | reject("in", grouped_by) | list %}
+{% if agreed.keys() | reject("in", grouped_by) | list or gathered %}
 **Labels**
 {% for key, value in agreed.items() if key not in grouped_by -%}
 - {{ pair(key, value) | trim }}
 {% endfor -%}
+{% if gathered -%}
+- {{ apart_keys[0] }}: {% for value in apart_values[:20] -%}
+{{ value if "`" in value else "`" ~ value ~ "`" }}{{ ", " if not loop.last }}
+{%- endfor -%}
+{{ " and " ~ (apart_values | length - 20) ~ " more" if apart_values | length > 20 }}
+{% endif -%}
 {% endif -%}
 
 {% if notes %}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -256,21 +256,23 @@ discord_message = """\
 {% endif -%}
 {% set description = annotations.get("description") -%}
 
-{# What identifies an instance is the labels the group does not share; a summary is prose that usually names them
-   and is not required to. So an instance says its own summary when its rule wrote one that is not already the
-   summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
-   every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
-{% set summaries = [] -%}
-{% set apart_keys = [] -%}
-{% set apart_values = [] -%}
+{# What identifies an instance is its own summary and the labels the group does not share. A summary is prose:
+   it usually names its instance and is not required to, so the labels the sentence does not carry are kept too —
+   gathered by key under Labels rather than trailing the sentence, because prose reads as prose and
+   `fra`, `syd` reads as one fact about the group. -#}
 {% set prose_lines = [] -%}
+{% set tuple_lines = [] -%}
+{% set varied = {} -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
 {% if own and own != summary -%}
 {% set prose = (own | string).split() | join(" ") -%}
-{% set _ = prose_lines.append(prose) -%}
 {% else -%}
 {% set prose = "" -%}
+{% endif -%}
+{# Two instances that wrote the same sentence read as one line; their labels below still count both. -#}
+{% if prose and prose not in prose_lines -%}
+{% set _ = prose_lines.append(prose) -%}
 {% endif -%}
 {# "Carries" means says as a word of its own: matching anywhere in the sentence read `shard: 1` into "12 jobs"
    and dropped the one label telling two shards apart. -#}
@@ -285,31 +287,25 @@ discord_message = """\
    and agreed.get(key) != value
    and (value | string) not in carried -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
-{% if key not in apart_keys -%}
-{% set _ = apart_keys.append(key) -%}
-{% endif -%}
 {% set flat = (value | string).split() | join(" ") -%}
-{% if flat not in apart_values -%}
-{% set _ = apart_values.append(flat) -%}
+{% if flat not in varied.get(key, []) -%}
+{% set _ = varied.update({key: varied.get(key, []) + [flat]}) -%}
 {% endif -%}
 {% endfor -%}
-{% if prose and apart -%}
-{% set line = prose ~ " — " ~ (apart | join(", ")) -%}
-{% elif prose -%}
-{% set line = prose -%}
-{% else -%}
-{% set line = apart | join(", ") -%}
-{% endif -%}
-{# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
-{% if line and line not in summaries -%}
-{% set _ = summaries.append(line) -%}
+{% if apart and (apart | join(", ")) not in tuple_lines -%}
+{% set _ = tuple_lines.append(apart | join(", ")) -%}
 {% endif -%}
 {% endfor -%}
 
-{# One label alone telling the instances apart gathers onto one line: a list of lines saying nothing but
-   `shard: 1` and `shard: 2` is a worse way to write `shard: 1, 2`. Two or more keys stay a line per
-   instance, because which value came with which is the information. -#}
-{% set gathered = (instances | length) > 1 and apart_keys | length == 1 and not prose_lines -%}
+{# Which value came with which is information the gathering loses, and when nothing else names the instances —
+   no prose, two or more keys — a line per instance keeps the pairing. Otherwise labels gather by key: prose
+   names its own instance, and one key has nothing to pair. -#}
+{% if not prose_lines and varied | length > 1 -%}
+{% set summaries = tuple_lines -%}
+{% set varied = {} -%}
+{% else -%}
+{% set summaries = prose_lines -%}
+{% endif -%}
 
 {# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
    of `values`, dropped only when there is a `values` to read instead of it. -#}
@@ -336,7 +332,7 @@ discord_message = """\
 
 {# A group of one has said its summary above. A group of many says one per instance, even when only one of them
    turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
-{% if summaries and not gathered and (instances | length) > 1 %}
+{% if summaries and (instances | length) > 1 %}
 **Summaries**
 {% for line in summaries[:20] -%}
 - {{ line }}
@@ -356,17 +352,17 @@ discord_message = """\
 {% endfor -%}
 {% endif -%}
 
-{% if agreed.keys() | reject("in", grouped_by) | list or gathered %}
+{% if agreed.keys() | reject("in", grouped_by) | list or varied %}
 **Labels**
 {% for key, value in agreed.items() if key not in grouped_by -%}
 - {{ pair(key, value) | trim }}
 {% endfor -%}
-{% if gathered -%}
-- {{ apart_keys[0] }}: {% for value in apart_values[:20] -%}
+{% for key, values in varied.items() -%}
+- {{ key }}: {% for value in values[:20] -%}
 {{ value if "`" in value else "`" ~ value ~ "`" }}{{ ", " if not loop.last }}
 {%- endfor -%}
-{{ " and " ~ (apart_values | length - 20) ~ " more" if apart_values | length > 20 }}
-{% endif -%}
+{{ " and " ~ (values | length - 20) ~ " more" if values | length > 20 }}
+{% endfor -%}
 {% endif -%}
 
 {% if notes %}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -257,12 +257,18 @@ discord_message = """\
 {% else -%}
 {% set prose = "" -%}
 {% endif -%}
+{# "Carries" means says as a word of its own: matching anywhere in the sentence read `shard: 1` into "12 jobs"
+   and dropped the one label telling two shards apart. -#}
+{% set carried = [] -%}
+{% for token in prose.split() -%}
+{% set _ = carried.append(token | trim("`.,:;!?()[]{}" ~ '"' ~ "'")) -%}
+{% endfor -%}
 {% set apart = [] -%}
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
    and agreed.get(key) != value
-   and (value | string) not in prose -%}
+   and (value | string) not in carried -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
 {% if prose and apart -%}

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -210,13 +210,13 @@ discord_title = web_title
 
 discord_message = """\
 {# A webhook carries one authoritative thing: `alerts`, every instance the group holds, each with its own labels
-   and annotations. `groupLabels`, `commonLabels` and `commonAnnotations` are views Alertmanager derives from
-   them — the part the instances agree on. The legacy integration sends no `alerts` and puts a single instance's
-   labels and annotations at the top level, so it is read here as a group of one and nothing below this block has
-   to know which shape arrived.
+   and annotations. Everything else is a view Alertmanager derives from them — `groupLabels` is what the route
+   grouped by, `commonLabels` and `commonAnnotations` are what the instances happen to agree on. The legacy
+   integration sends no `alerts` and puts a single instance's labels and annotations at the top level, so it is
+   read here as a group of one and nothing after this block has to know which shape arrived.
 
-   A card says the agreed part once, and names the instances when there is more than one, because what sets them
-   apart is exactly what the agreed part cannot carry. -#}
+   A card says the agreed part once, and lists a summary per instance when it holds more than one, because what
+   sets the instances apart is exactly what the agreed part cannot carry. -#}
 {% macro pair(key, value) -%}
 {% set flat = (value | string).split() | join(" ") -%}
 {% if "`" in flat -%}
@@ -230,25 +230,26 @@ discord_message = """\
    Grafana wraps its own identifiers in double underscores and hides them in its own UI. -#}
 {% set said_elsewhere = ["alertname", "severity"] -%}
 {% set instances = payload.get("alerts") or [{"labels": payload.get("labels", {}), "annotations": payload.get("annotations", {})}] -%}
-{% set agreed = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
-{% set shared = {} -%}
-{% for source in [payload.get("groupLabels", {}), payload.get("commonLabels", {}), payload.get("labels", {})] -%}
+{% set grouped_by = payload.get("groupLabels", {}) -%}
+{% set annotations = payload.get("commonAnnotations") or payload.get("annotations", {}) -%}
+{% set agreed = {} -%}
+{% for source in [grouped_by, payload.get("commonLabels", {}), payload.get("labels", {})] -%}
 {% for key, value in source.items()
-   if key not in shared
+   if key not in agreed
    and key not in said_elsewhere
    and not key.startswith("__") -%}
-{% set _ = shared.update({key: value}) -%}
+{% set _ = agreed.update({key: value}) -%}
 {% endfor -%}
 {% endfor -%}
 
-{% set summary = agreed.get("summary") -%}
-{% set description = agreed.get("description") -%}
+{% set summary = annotations.get("summary") -%}
+{% set description = annotations.get("description") -%}
 
-{# What identifies an instance is the labels the group does not share; a summary is prose that usually names
-   them and is not required to. So an instance says its own summary when its rule wrote one that is not already
-   the summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
+{# What identifies an instance is the labels the group does not share; a summary is prose that usually names them
+   and is not required to. So an instance says its own summary when its rule wrote one that is not already the
+   summary above, and then adds whichever of its own labels that sentence does not carry. A rule that writes
    every instance the same sentence identifies none of them, and then the labels are all a line has to go on. -#}
-{% set listed = [] -%}
+{% set summaries = [] -%}
 {% for instance in instances -%}
 {% set own = instance.get("annotations", {}).get("summary") -%}
 {% if own and own != summary -%}
@@ -260,7 +261,7 @@ discord_message = """\
 {% for key, value in instance.get("labels", {}).items()
    if key not in said_elsewhere
    and not key.startswith("__")
-   and shared.get(key) != value
+   and agreed.get(key) != value
    and (value | string) not in prose -%}
 {% set _ = apart.append(pair(key, value) | trim) -%}
 {% endfor -%}
@@ -272,20 +273,20 @@ discord_message = """\
 {% set line = apart | join(", ") -%}
 {% endif -%}
 {# Two instances reduced to the same line are the same instance as far as a reader can tell. -#}
-{% if line and line not in listed -%}
-{% set _ = listed.append(line) -%}
+{% if line and line not in summaries -%}
+{% set _ = summaries.append(line) -%}
 {% endif -%}
 {% endfor -%}
 
 {# The prose above and the link buttons are not repeated as lines to copy out of. `value_string` is the long form
    of `values`, dropped only when there is a `values` to read instead of it. -#}
 {% set spoken = ["summary", "description", "runbook_url", "runbook_url_internal", "dashboard_url", "dashboardURL"] -%}
-{% set spoken = spoken + ["value_string"] if agreed.get("values") else spoken -%}
+{% set spoken = spoken + ["value_string"] if annotations.get("values") else spoken -%}
 {% set notes = [] -%}
-{% for key, value in agreed.items()
+{% for key, value in annotations.items()
    if key not in spoken
    and not key.startswith("__")
-   and shared.get(key) != value -%}
+   and agreed.get(key) != value -%}
 {% set _ = notes.append(pair(key, value) | trim) -%}
 {% endfor -%}
 
@@ -300,21 +301,31 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
-{# A group of one has said everything it has above. A group of many says what is in it, even when only one of
-   them turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
-{% if listed and (instances | length) > 1 %}
-**Instances**
-{% for line in listed[:20] -%}
+{# A group of one has said its summary above. A group of many says one per instance, even when only one of them
+   turned out to carry anything of its own: that line is then the only thing naming what failed. -#}
+{% if summaries and (instances | length) > 1 %}
+**Summaries**
+{% for line in summaries[:20] -%}
 - {{ line }}
 {% endfor -%}
-{% if listed | length > 20 -%}
-- and {{ listed | length - 20 }} more
+{% if summaries | length > 20 -%}
+- and {{ summaries | length - 20 }} more
 {% endif -%}
 {% endif -%}
 
-{% if shared %}
+{# What the route grouped by, and then what the instances turned out to share beyond it. Kept apart because they
+   answer different questions: the first is why these alerts arrived as one card, the second is what they have in
+   common once they had. -#}
+{% if agreed.keys() | select("in", grouped_by) | list %}
+**Group**
+{% for key, value in agreed.items() if key in grouped_by -%}
+- {{ pair(key, value) | trim }}
+{% endfor -%}
+{% endif -%}
+
+{% if agreed.keys() | reject("in", grouped_by) | list %}
 **Labels**
-{% for key, value in shared.items() -%}
+{% for key, value in agreed.items() if key not in grouped_by -%}
 - {{ pair(key, value) | trim }}
 {% endfor -%}
 {% endif -%}
@@ -326,11 +337,11 @@ discord_message = """\
 {% endfor -%}
 {% endif -%}
 
-{% if agreed.get("runbook_url") -%}
-[:book: Runbook]({{ agreed.runbook_url }})
+{% if annotations.get("runbook_url") -%}
+[:book: Runbook]({{ annotations.runbook_url }})
 {% endif -%}
-{% if agreed.get("runbook_url_internal") -%}
-[:closed_book: Runbook (internal)]({{ agreed.runbook_url_internal }})
+{% if annotations.get("runbook_url_internal") -%}
+[:closed_book: Runbook (internal)]({{ annotations.runbook_url_internal }})
 {% endif -%}
 """  # noqa
 

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -261,6 +261,40 @@ discord_message = """\
 {{ description }}
 {% endif -%}
 
+{# One group can hold an instance per worker, region or host, and the route decides what they share: a label that
+   differs between them is in neither commonLabels nor commonAnnotations, and neither is a summary written from
+   it. Grouped by alertname alone, a card would name none of the things that are actually failing, so each
+   instance says itself — by its own summary, or by the labels that set it apart from the group. -#}
+{% set instances = [] -%}
+{% for alert in payload.get("alerts", []) -%}
+{% set own = alert.get("annotations", {}).get("summary") -%}
+{% if own -%}
+{% set _ = instances.append((own | string).split() | join(" ")) -%}
+{% else -%}
+{% set apart = [] -%}
+{% for key, value in alert.get("labels", {}).items()
+   if key not in ["alertname", "severity"]
+   and not key.startswith("__")
+   and commonLabels.get(key) != value -%}
+{% set _ = apart.append(key ~ ": `" ~ value ~ "`") -%}
+{% endfor -%}
+{% if apart -%}
+{% set _ = instances.append(apart | join(", ")) -%}
+{% endif -%}
+{% endif -%}
+{% endfor -%}
+
+{# A group of one already says everything it has in the lines above. -#}
+{% if instances | length > 1 %}
+**Instances**
+{% for entry in instances[:20] -%}
+- {{ entry }}
+{% endfor -%}
+{% if instances | length > 20 -%}
+- and {{ instances | length - 20 }} more
+{% endif -%}
+{% endif -%}
+
 {% if labels %}
 **Labels**
 {% for entry in labels -%}


### PR DESCRIPTION
## What

The Discord card template (alertmanager + grafana_alerting) now reads `payload.alerts` — the instances a group actually holds — instead of only the `commonLabels`/`commonAnnotations` views derived from them. Three things change on a card:

1. **A group of many names each instance it holds.** A new **Summaries** section lists each instance's own summary as a line of prose, and the labels those sentences do not already say gather by key under **Labels** (`deployment_region_name: fra, syd`). What sets the instances apart is exactly what the common labels cannot carry, so before this a card could only say "a queue somewhere has failed jobs" — never which queue. When no instance wrote a summary and two or more label keys vary, the card keeps a compact line per instance instead, because which value came with which is then the only identity.
2. **Group is kept apart from Labels.** `groupLabels` says why these alerts arrived as one card; `commonLabels` says what they turned out to share. They now get a heading each instead of being merged.
3. **"The sentence already says this label" is judged by words, not substrings.** A raw substring match read `shard: 1` into "12 jobs" and dropped the one label telling two shards apart — with identical summaries the lines then collapsed back into one. Tokens are now compared word-by-word (backticks and punctuation stripped), so a rule that names its instance in prose still keeps its line clean.
4. **A sentence every instance says is hoisted.** When every instance was written the same summary, it is the group's summary — whichever field the sender put it in — and is said once at the top rather than on a line per instance.

The legacy no-`alerts` payload shape is normalized into a group of one up front and renders as it did. Slack/Telegram/web templates are untouched.

## Example

The default Grafana notification policy groups by `grafana_folder` + `alertname`, so one rule watching many queues arrives as a single group. `service_name` differs per instance (keeping it out of `commonLabels`) and each summary is written from it (keeping every summary out of `commonAnnotations`) — so the old card had nowhere to say what actually failed.

**Before:**

```
This alert starts when a queue is holding more failed jobs than it was.

**Labels**
- grafana_folder: `Utopia`
- deployment_cluster_name: `cloud`
- team: `cloud`
```

**After:**

```
This alert starts when a queue is holding more failed jobs than it was.

**Summaries**
- The `builds` queue on `cloud-fra1-prod` gained 2384 failed jobs in an hour.
- The `domains` queue on `cloud-syd1-prod` gained 12825 failed jobs in an hour.

**Group**
- grafana_folder: `Utopia`

**Labels**
- deployment_cluster_name: `cloud`
- team: `cloud`
- deployment_region_name: `fra`, `syd`
```

And a rule that writes every instance the same sentence, distinguishable only by one label:

**Before:**

```
**Labels**
- team: `cloud`
```

**After:**

```
The queue gained 12 failed jobs.

**Labels**
- team: `cloud`
- shard: `1`, `2`
```

## Notes

- Summaries are capped at 20 lines and a gathered label at 20 values, each plus "and N more"; the embed truncation still applies on top.
- Two instances that wrote the same sentence read as one Summaries line; the gathered labels below still count both.
- One visible change for existing single-alert groups: labels the route grouped by now sit under **Group** instead of **Labels**.
- Slack, Telegram, and web still render the flat `GroupLabels:`/`CommonLabels:` dump and never name instances; porting this there is a possible follow-up.

## Verification

- `apps/discord/tests/test_alert_rendering.py` grows 13 template tests parametrized over both integration modules, including regressions for the shard-collapse, punctuation-fenced words, hoisting, and per-key gathering.
- Full run: 110 passed across `test_alert_rendering`, `test_default_templates`, and `test_alert_group_renderer` (127 with the discord backend/representative suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
