### PR TITLE
fix(discord): don't import ResolutionNote while apps.alerts.models initializes

### DIFF
--- a/engine/apps/discord/alert_rendering.py
+++ b/engine/apps/discord/alert_rendering.py
@@ -6,9 +6,15 @@ from emoji import emojize
 
 from apps.alerts.incident_appearance.renderers.base_renderer import AlertBaseRenderer, AlertGroupBaseRenderer
 from apps.alerts.incident_appearance.templaters.alert_templater import AlertTemplater
-from apps.alerts.models import Alert, AlertGroup, ResolutionNote
+from apps.alerts.models import Alert, AlertGroup
 from apps.discord.client import THREAD_NAME_LIMIT
 from common.utils import is_string_with_visible_characters, str_or_backup
+
+if typing.TYPE_CHECKING:
+    # Only for annotation. Importing it at module level deadlocks startup: loading the
+    # messaging backends is part of initializing apps.alerts.models, and ResolutionNote
+    # is not bound there yet when this module is pulled in through DiscordBackend.
+    from apps.alerts.models import ResolutionNote
 
 # https://discord.com/developers/docs/resources/message#embed-object-embed-limits
 EMBED_TITLE_LIMIT = 256
@@ -95,7 +101,7 @@ def stamp(moment) -> str:
     return f"<t:{seconds}:t> (<t:{seconds}:R>)"
 
 
-def render_resolution_note(resolution_note: ResolutionNote) -> dict:
+def render_resolution_note(resolution_note: "ResolutionNote") -> dict:
     """A resolution note as a follow-up beside the card.
 
     The note is already capped at 3000 characters in OnCall, which fits an embed


### PR DESCRIPTION
## Why

Every release since v1.23.0 fails to boot when `FEATURE_DISCORD_INTEGRATION_ENABLED=True` — this is what took the telemetry stack's OnCall down on the v1.24.2 upgrade (appwrite-labs/monitoring#377):

```
File "/etc/app/apps/discord/backend.py", line 4, in <module>
File "/etc/app/apps/discord/alert_rendering.py", line 9, in <module>
ImportError: cannot import name 'ResolutionNote' from partially initialized module 'apps.alerts.models'
```

## The cycle

Loading the messaging backends is itself part of initializing `apps.alerts.models`:

`apps/alerts/models/__init__.py` → `alert_receive_channel` → `apps.integrations.tasks` → `common.custom_celery_tasks` → `apps.base.models` → `UserNotificationPolicy` builds its notification-channel choices at class-definition time → `get_messaging_backends()` imports `DiscordBackend` → `alert_rendering.py` line 9 imports `apps.alerts.models` back while it is still initializing.

`Alert` and `AlertGroup` survive only because they are bound on the first two lines of the package's `__init__`, before the cycle re-enters. `ResolutionNote` (added to this import in v1.23.0 alongside `render_resolution_note`) is bound later, so boot dies.

## Fix

`ResolutionNote` is only used as a type annotation here, so it moves behind `typing.TYPE_CHECKING` with a comment explaining why it must not be imported at module level.

## Verification

Mounted the patched file into the released `ghcr.io/appwrite/grafana-oncall:v1.24.2` image and ran `manage.py migrate` with the production environment including `FEATURE_DISCORD_INTEGRATION_ENABLED=True`: full app registry loads and migrations complete. Unpatched, the same command reproduces the ImportError on v1.23.0, v1.24.0, v1.24.1 and v1.24.2. `ruff check` and `ruff format --check` pass.

## Note for the next monitoring upgrade

~~v1.24.x also bumps django-mirage-field, which now asserts `SECRET_KEY` is ≥32 characters, and the production key is shorter.~~ **Correction:** both v1.22.4 and v1.24.2 ship the identical django-mirage-field 1.3.0 with the identical ≥32-character assertion — it only fired in the first reproduction because the dummy test key was 20 characters. Production runs v1.22.4 through this same code path, so its key already satisfies the check. This circular import is the only thing blocking the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
