### PR TITLE
ci: test against Grafana 13.2

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -11,4 +11,4 @@ changelog:
         - release:enhancement
     - title: Other Changes
       labels:
-        - release:patch
+        - "*"

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -356,7 +356,7 @@ jobs:
       matrix:
         grafana_version:
           - 12.4.8
-          - 13.1.3
+          - 13.2.0
       fail-fast: false
     with:
       grafana_version: ${{ matrix.grafana_version }}

--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ New features:
 
 - A [Discord integration](docs/sources/manage/notify/discord/index.md). Alert groups are posted as
   cards with working buttons, forum channels get a post per alert group, routes choose a channel and
-  a severity, and escalation can mention a Discord role. Users link their account with
+  a severity, and escalation can mention a Discord role. Cards identify every alert instance in a
+  group, and resolution notes stay synchronized beside them. Users link their account with
   `/oncall-link`.
 - SMS through [MSG91](https://msg91.com), as a phone provider alongside Twilio, Zvonok and Exotel.
 
 Kept working:
 
-- Runs on Grafana 13 and React 19. Upstream's plugin crashes on mount there.
+- Runs on Grafana 13.2 and React 19. Upstream's plugin crashes on mount there.
 - Runs on Django 5.2 LTS. Upstream is on 4.2, whose extended support has ended.
 - The Insights page renders again. Its alert group variable produced invalid PromQL on Grafana 13.
-- Dependencies are patched, and end-to-end tests run against Grafana 12 and 13.
+- Dependencies are patched, and end-to-end tests run against Grafana 12.4 and 13.2.
 
 Published:
 
@@ -164,7 +165,7 @@ variable moves both. Set it to the [release](https://github.com/appwrite/grafana
 want in `.env`:
 
 ```shell
-echo "ONCALL_VERSION=1.19.1" >> .env
+echo "ONCALL_VERSION=1.24.3" >> .env
 
 docker-compose pull
 docker-compose up -d

--- a/docs/sources/manage/notify/discord/index.md
+++ b/docs/sources/manage/notify/discord/index.md
@@ -30,6 +30,12 @@ which alert group it is, and how many alerts the group holds.
 The **Timeline** field is written in Discord's own timestamps, so everyone reads it on their own clock and in their
 own timezone — "Fired 00:12 (3 hours ago)", then who acknowledged it and when, then how long it took to resolve.
 
+When an alert group contains several alert instances, the card lists each distinct instance summary under
+**Summaries**. Labels that vary between instances are gathered by key under **Labels**, while the labels that made
+Grafana group the alerts stay separate under **Group**. This keeps a grouped notification compact without hiding
+which queue, shard, host, or other instance actually fired. A card shows up to 20 summaries and 20 values for each
+gathered label, followed by the number of remaining items.
+
 Acknowledging or resolving — from Discord or anywhere else — edits the same message in place:
 
 ![The same alert group after being acknowledged, showing who acknowledged it](img/alert-acknowledged.png)
@@ -125,8 +131,8 @@ their own notification policies, so that who gets woken respects who is actually
 alert group has already been acknowledged, silenced or resolved by the time the step runs.
 
 A resolution note created from the OnCall UI or the public API is posted the same way: beside the card, in the
-forum post or as a reply in a text channel. Mentions stay off. The alert group's `permalinks.discord` is a URL
-to that card.
+forum post or as a reply in a text channel. Editing or deleting the note updates or removes its Discord message.
+Mentions stay off. The alert group's `permalinks.discord` is a URL to that card.
 
 ## Split critical alerts from the rest
 

--- a/grafana-plugin/e2e-tests/escalationChains/escalationPolicy.test.ts
+++ b/grafana-plugin/e2e-tests/escalationChains/escalationPolicy.test.ts
@@ -32,9 +32,6 @@ test('from_time and to_time for "Continue escalation if current UTC time is in r
 
   const clickAndInputValue = async (locator: Locator, value: string) => {
     await typeTime(locator, value);
-
-    // click anywhere to close the dropdown
-    await page.click('body');
   };
 
   // update from and to time values

--- a/grafana-plugin/e2e-tests/utils/schedule.ts
+++ b/grafana-plugin/e2e-tests/utils/schedule.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from '@playwright/test';
+import { expect, Locator, Page } from '@playwright/test';
 import dayjs from 'dayjs';
 
 import { clickButton, selectDropdownValue } from './forms';
@@ -84,9 +84,9 @@ export const setTime = async (element: Locator, hour: string) => {
  * list, so type first and correct it from the list when the typing did not stick.
  */
 export const typeTime = async (input: Locator, value: string) => {
-  await input.click();
-  await input.fill('');
-  await input.pressSequentially(value);
+  // fill focuses and replaces the value in one action. Separate click/clear/type actions race with
+  // the controlled combobox remount introduced in Grafana 13.2.
+  await input.fill(value);
 
   // grafana 13 renders a combobox that only commits a value picked from its list; 12 takes the
   // typed value on Enter. Don't click the input again here — that would close the open list.
@@ -98,6 +98,8 @@ export const typeTime = async (input: Locator, value: string) => {
   } catch {
     await input.press('Enter');
   }
+
+  await expect(input).toHaveValue(value);
 };
 
 /** the open menu of a grafana Select, which is portalled out of its container */


### PR DESCRIPTION
## Summary

- test the plugin against Grafana 13.2.0 instead of 13.1.3
- document the current Grafana compatibility and recent Discord grouped-alert and resolution-note behavior
- include unlabeled pull requests in generated release notes so future descriptions are not empty
- refresh the README's pinned release example

The GitHub release descriptions for v1.23.0 through v1.24.3 were also backfilled directly, including upgrade warnings on the Discord startup regression affected releases.

## Validation

- `uvx pre-commit run --files .github/release.yml .github/workflows/linting-and-tests.yml README.md docs/sources/manage/notify/discord/index.md`
- `git diff --check`
