### PR TITLE
fix: secure self-hosted plugin installation (CVE-2026-63087)

### DIFF
--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -28,6 +28,7 @@ x-env-files: &oncall-env-files
 x-env-vars: &oncall-env-vars
   BROKER_TYPE: ${BROKER_TYPE}
   GRAFANA_API_URL: http://localhost:3000
+  GRAFANA_PUBLIC_URL: ${GRAFANA_PUBLIC_URL:-}
   GOOGLE_APPLICATION_CREDENTIALS: /etc/app/gcp_service_account.json
   FCM_PROJECT_ID: oncall-mobile-dev
 

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -19,6 +19,7 @@ x-environment: &oncall-environment
   CELERY_WORKER_SHUTDOWN_INTERVAL: "65m"
   CELERY_WORKER_BEAT_ENABLED: "True"
   GRAFANA_API_URL: http://grafana:3000
+  GRAFANA_PUBLIC_URL: ${GRAFANA_PUBLIC_URL:-}
 
 services:
   engine:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-environment: &oncall-environment
   CELERY_WORKER_SHUTDOWN_INTERVAL: "65m"
   CELERY_WORKER_BEAT_ENABLED: "True"
   GRAFANA_API_URL: http://grafana:3000
+  GRAFANA_PUBLIC_URL: ${GRAFANA_PUBLIC_URL:-}
 
 services:
   engine:

--- a/engine/apps/grafana_plugin/tests/test_install_v2.py
+++ b/engine/apps/grafana_plugin/tests/test_install_v2.py
@@ -11,6 +11,7 @@ from apps.grafana_plugin.views.sync_v2 import SyncException
 from common.api_helpers.errors import INVALID_SELF_HOSTED_ID
 
 GRAFANA_URL = "http://trusted-grafana:3000"
+PUBLIC_GRAFANA_URL = "https://grafana.example.com"
 GRAFANA_TOKEN = "a-valid-grafana-token"
 SELF_HOSTED_SETTINGS = {**settings.SELF_HOSTED_SETTINGS, "GRAFANA_API_URL": GRAFANA_URL}
 
@@ -31,23 +32,37 @@ def test_install_v2_fails_closed_without_a_configured_grafana_url():
 
 
 @override_settings(SELF_HOSTED_SETTINGS=SELF_HOSTED_SETTINGS)
-@pytest.mark.parametrize(
-    ("grafana_url", "grafana_token"),
-    [
-        ("http://attacker-grafana:3000", GRAFANA_TOKEN),
-        (GRAFANA_URL, "short"),
-    ],
-)
-def test_install_v2_rejects_untrusted_grafana_or_invalid_token(grafana_url, grafana_token):
+def test_install_v2_rejects_invalid_token():
     client = APIClient()
 
     with patch("apps.grafana_plugin.views.install_v2.GrafanaAPIClient.get_service_account_token_permissions") as auth:
-        response = client.post(
-            reverse("grafana-plugin:install-v2"), install_data(grafana_url, grafana_token), format="json"
-        )
+        response = client.post(reverse("grafana-plugin:install-v2"), install_data(grafana_token="short"), format="json")
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     auth.assert_not_called()
+
+
+@override_settings(SELF_HOSTED_SETTINGS=SELF_HOSTED_SETTINGS)
+def test_install_v2_validates_token_against_configured_grafana_url():
+    client = APIClient()
+    permissions = {"plugins:write": ["plugins:id:grafana-oncall-app"]}
+    exc = SyncException(INVALID_SELF_HOSTED_ID)
+
+    with (
+        patch("apps.grafana_plugin.views.install_v2.GrafanaAPIClient") as grafana_api_client,
+        patch("apps.grafana_plugin.views.InstallV2View.do_sync", side_effect=exc),
+    ):
+        grafana_api_client.validate_grafana_token_format.return_value = True
+        grafana_api_client.return_value.get_service_account_token_permissions.return_value = (
+            permissions,
+            {"connected": True},
+        )
+        response = client.post(
+            reverse("grafana-plugin:install-v2"), install_data(grafana_url=PUBLIC_GRAFANA_URL), format="json"
+        )
+
+    grafana_api_client.assert_called_once_with(api_url=GRAFANA_URL, api_token=GRAFANA_TOKEN)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 @override_settings(SELF_HOSTED_SETTINGS=SELF_HOSTED_SETTINGS)

--- a/engine/apps/grafana_plugin/tests/test_install_v2.py
+++ b/engine/apps/grafana_plugin/tests/test_install_v2.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -8,18 +10,85 @@ from rest_framework.test import APIClient
 from apps.grafana_plugin.views.sync_v2 import SyncException
 from common.api_helpers.errors import INVALID_SELF_HOSTED_ID
 
+GRAFANA_URL = "http://trusted-grafana:3000"
+GRAFANA_TOKEN = "a-valid-grafana-token"
+SELF_HOSTED_SETTINGS = {**settings.SELF_HOSTED_SETTINGS, "GRAFANA_API_URL": GRAFANA_URL}
 
-@pytest.mark.django_db
-def test_install_v2_error_encoding(make_organization_and_user_with_plugin_token, make_user_auth_headers):
-    organization, user, token = make_organization_and_user_with_plugin_token()
+
+def install_data(grafana_url=GRAFANA_URL, grafana_token=GRAFANA_TOKEN):
+    return {"settings": {"grafana_url": grafana_url, "grafana_token": grafana_token}}
+
+
+@override_settings(SELF_HOSTED_SETTINGS={**SELF_HOSTED_SETTINGS, "GRAFANA_API_URL": None})
+def test_install_v2_fails_closed_without_a_configured_grafana_url():
     client = APIClient()
 
-    auth_headers = make_user_auth_headers(user, token)
+    with patch("apps.grafana_plugin.views.InstallV2View.do_sync") as do_sync:
+        response = client.post(reverse("grafana-plugin:install-v2"), install_data(), format="json")
 
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    do_sync.assert_not_called()
+
+
+@override_settings(SELF_HOSTED_SETTINGS=SELF_HOSTED_SETTINGS)
+@pytest.mark.parametrize(
+    ("grafana_url", "grafana_token"),
+    [
+        ("http://attacker-grafana:3000", GRAFANA_TOKEN),
+        (GRAFANA_URL, "short"),
+    ],
+)
+def test_install_v2_rejects_untrusted_grafana_or_invalid_token(grafana_url, grafana_token):
+    client = APIClient()
+
+    with patch("apps.grafana_plugin.views.install_v2.GrafanaAPIClient.get_service_account_token_permissions") as auth:
+        response = client.post(
+            reverse("grafana-plugin:install-v2"), install_data(grafana_url, grafana_token), format="json"
+        )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    auth.assert_not_called()
+
+
+@override_settings(SELF_HOSTED_SETTINGS=SELF_HOSTED_SETTINGS)
+@pytest.mark.parametrize(
+    ("permissions", "connected"),
+    [
+        ({"plugins:write": ["plugins:id:another-plugin"]}, True),
+        ({"plugins:write": ["plugins:id:grafana-oncall-app"]}, False),
+    ],
+)
+def test_install_v2_requires_plugin_write_permission_from_trusted_grafana(permissions, connected):
+    client = APIClient()
+
+    with (
+        patch(
+            "apps.grafana_plugin.views.install_v2.GrafanaAPIClient.get_service_account_token_permissions",
+            return_value=(permissions, {"connected": connected}),
+        ),
+        patch("apps.grafana_plugin.views.InstallV2View.do_sync") as do_sync,
+    ):
+        response = client.post(reverse("grafana-plugin:install-v2"), install_data(), format="json")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    do_sync.assert_not_called()
+
+
+@override_settings(SELF_HOSTED_SETTINGS=SELF_HOSTED_SETTINGS)
+def test_install_v2_error_encoding_for_authorized_grafana_token():
+    client = APIClient()
+    permissions = {"plugins:write": ["plugins:id:grafana-oncall-app"]}
     exc = SyncException(INVALID_SELF_HOSTED_ID)
 
-    with patch("apps.grafana_plugin.views.InstallV2View.do_sync", side_effect=exc):
-        response = client.post(reverse("grafana-plugin:install-v2"), format="json", **auth_headers)
-        assert response.data["code"] == INVALID_SELF_HOSTED_ID.code
-        assert response.data["message"] == INVALID_SELF_HOSTED_ID.message
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+    with (
+        patch(
+            "apps.grafana_plugin.views.install_v2.GrafanaAPIClient.get_service_account_token_permissions",
+            return_value=(permissions, {"connected": True}),
+        ),
+        patch("apps.grafana_plugin.views.InstallV2View.do_sync", side_effect=exc),
+    ):
+        response = client.post(reverse("grafana-plugin:install-v2"), install_data(), format="json")
+
+    assert response.data["code"] == INVALID_SELF_HOSTED_ID.code
+    assert response.data["message"] == INVALID_SELF_HOSTED_ID.message
+    assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/engine/apps/grafana_plugin/tests/test_install_v2.py
+++ b/engine/apps/grafana_plugin/tests/test_install_v2.py
@@ -13,10 +13,14 @@ from common.api_helpers.errors import INVALID_SELF_HOSTED_ID
 GRAFANA_URL = "http://trusted-grafana:3000"
 PUBLIC_GRAFANA_URL = "https://grafana.example.com"
 GRAFANA_TOKEN = "a-valid-grafana-token"
-SELF_HOSTED_SETTINGS = {**settings.SELF_HOSTED_SETTINGS, "GRAFANA_API_URL": GRAFANA_URL}
+SELF_HOSTED_SETTINGS = {
+    **settings.SELF_HOSTED_SETTINGS,
+    "GRAFANA_API_URL": GRAFANA_URL,
+    "GRAFANA_PUBLIC_URL": PUBLIC_GRAFANA_URL,
+}
 
 
-def install_data(grafana_url=GRAFANA_URL, grafana_token=GRAFANA_TOKEN):
+def install_data(grafana_url=PUBLIC_GRAFANA_URL, grafana_token=GRAFANA_TOKEN):
     return {"settings": {"grafana_url": grafana_url, "grafana_token": grafana_token}}
 
 
@@ -37,6 +41,21 @@ def test_install_v2_rejects_invalid_token():
 
     with patch("apps.grafana_plugin.views.install_v2.GrafanaAPIClient.get_service_account_token_permissions") as auth:
         response = client.post(reverse("grafana-plugin:install-v2"), install_data(grafana_token="short"), format="json")
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    auth.assert_not_called()
+
+
+@override_settings(SELF_HOSTED_SETTINGS=SELF_HOSTED_SETTINGS)
+def test_install_v2_rejects_untrusted_public_grafana_url():
+    client = APIClient()
+
+    with patch("apps.grafana_plugin.views.install_v2.GrafanaAPIClient.get_service_account_token_permissions") as auth:
+        response = client.post(
+            reverse("grafana-plugin:install-v2"),
+            install_data(grafana_url="https://attacker.example.com"),
+            format="json",
+        )
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     auth.assert_not_called()

--- a/engine/apps/grafana_plugin/views/install_v2.py
+++ b/engine/apps/grafana_plugin/views/install_v2.py
@@ -6,8 +6,10 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from apps.grafana_plugin.helpers import GrafanaAPIClient
 from apps.grafana_plugin.views.sync_v2 import SyncException, SyncV2View
 from common.api_helpers.errors import SELF_HOSTED_ONLY_FEATURE_ERROR
+from common.constants.plugin_ids import PluginID
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +18,39 @@ class InstallV2View(SyncV2View):
     authentication_classes = ()
     permission_classes = ()
 
+    @staticmethod
+    def _is_authorized(request: Request) -> bool:
+        configured_grafana_url = settings.SELF_HOSTED_SETTINGS["GRAFANA_API_URL"]
+        try:
+            sync_settings = request.data["settings"]
+            supplied_grafana_url = sync_settings["grafana_url"]
+            grafana_token = sync_settings["grafana_token"]
+        except (KeyError, TypeError):
+            return False
+
+        if (
+            not configured_grafana_url
+            or not isinstance(supplied_grafana_url, str)
+            or supplied_grafana_url.rstrip("/") != configured_grafana_url.rstrip("/")
+            or not GrafanaAPIClient.validate_grafana_token_format(grafana_token)
+        ):
+            return False
+
+        grafana_api_client = GrafanaAPIClient(api_url=configured_grafana_url, api_token=grafana_token)
+        permissions, call_status = grafana_api_client.get_service_account_token_permissions()
+        required_scope = f"plugins:id:{PluginID.ONCALL}"
+        return (
+            call_status["connected"]
+            and isinstance(permissions, dict)
+            and required_scope in permissions.get("plugins:write", [])
+        )
+
     def post(self, request: Request) -> Response:
         if settings.LICENSE != settings.OPEN_SOURCE_LICENSE_NAME:
             return Response(data=asdict(SELF_HOSTED_ONLY_FEATURE_ERROR), status=status.HTTP_403_FORBIDDEN)
+
+        if not self._is_authorized(request):
+            return Response(status=status.HTTP_401_UNAUTHORIZED)
 
         try:
             organization = self.do_sync(request)

--- a/engine/apps/grafana_plugin/views/install_v2.py
+++ b/engine/apps/grafana_plugin/views/install_v2.py
@@ -22,20 +22,15 @@ class InstallV2View(SyncV2View):
     def _is_authorized(request: Request) -> bool:
         configured_grafana_url = settings.SELF_HOSTED_SETTINGS["GRAFANA_API_URL"]
         try:
-            sync_settings = request.data["settings"]
-            supplied_grafana_url = sync_settings["grafana_url"]
-            grafana_token = sync_settings["grafana_token"]
+            grafana_token = request.data["settings"]["grafana_token"]
         except (KeyError, TypeError):
             return False
 
-        if (
-            not configured_grafana_url
-            or not isinstance(supplied_grafana_url, str)
-            or supplied_grafana_url.rstrip("/") != configured_grafana_url.rstrip("/")
-            or not GrafanaAPIClient.validate_grafana_token_format(grafana_token)
-        ):
+        if not configured_grafana_url or not GrafanaAPIClient.validate_grafana_token_format(grafana_token):
             return False
 
+        # Always authenticate against the operator-configured Grafana. The URL in the sync payload
+        # may be Grafana's different public URL and must not select the authorization authority.
         grafana_api_client = GrafanaAPIClient(api_url=configured_grafana_url, api_token=grafana_token)
         permissions, call_status = grafana_api_client.get_service_account_token_permissions()
         required_scope = f"plugins:id:{PluginID.ONCALL}"

--- a/engine/apps/grafana_plugin/views/install_v2.py
+++ b/engine/apps/grafana_plugin/views/install_v2.py
@@ -20,18 +20,27 @@ class InstallV2View(SyncV2View):
 
     @staticmethod
     def _is_authorized(request: Request) -> bool:
-        configured_grafana_url = settings.SELF_HOSTED_SETTINGS["GRAFANA_API_URL"]
+        configured_api_url = settings.SELF_HOSTED_SETTINGS["GRAFANA_API_URL"]
+        configured_public_url = settings.SELF_HOSTED_SETTINGS.get("GRAFANA_PUBLIC_URL") or configured_api_url
         try:
-            grafana_token = request.data["settings"]["grafana_token"]
+            sync_settings = request.data["settings"]
+            supplied_grafana_url = sync_settings["grafana_url"]
+            grafana_token = sync_settings["grafana_token"]
         except (KeyError, TypeError):
             return False
 
-        if not configured_grafana_url or not GrafanaAPIClient.validate_grafana_token_format(grafana_token):
+        if (
+            not configured_api_url
+            or not configured_public_url
+            or not isinstance(supplied_grafana_url, str)
+            or supplied_grafana_url.rstrip("/") != configured_public_url.rstrip("/")
+            or not GrafanaAPIClient.validate_grafana_token_format(grafana_token)
+        ):
             return False
 
-        # Always authenticate against the operator-configured Grafana. The URL in the sync payload
-        # may be Grafana's different public URL and must not select the authorization authority.
-        grafana_api_client = GrafanaAPIClient(api_url=configured_grafana_url, api_token=grafana_token)
+        # Authenticate through the operator-configured internal endpoint. The separately configured
+        # public URL is safe to persist for links and subsequent API calls because it is also operator-controlled.
+        grafana_api_client = GrafanaAPIClient(api_url=configured_api_url, api_token=grafana_token)
         permissions, call_status = grafana_api_client.get_service_account_token_permissions()
         required_scope = f"plugins:id:{PluginID.ONCALL}"
         return (

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -871,6 +871,7 @@ SELF_HOSTED_SETTINGS = {
     "ORG_TITLE": os.environ.get("SELF_HOSTED_ORG_TITLE", "Self-Hosted Organization"),
     "REGION_SLUG": os.environ.get("SELF_HOSTED_REGION_SLUG", "self_hosted_region"),
     "GRAFANA_API_URL": os.environ.get("GRAFANA_API_URL", default=None),
+    "GRAFANA_PUBLIC_URL": os.environ.get("GRAFANA_PUBLIC_URL") or os.environ.get("GRAFANA_API_URL", default=None),
     "CLUSTER_SLUG": os.environ.get("SELF_HOSTED_CLUSTER_SLUG", "self_hosted_cluster"),
 }
 

--- a/grafana-plugin/e2e-tests/utils/schedule.ts
+++ b/grafana-plugin/e2e-tests/utils/schedule.ts
@@ -99,6 +99,15 @@ export const typeTime = async (input: Locator, value: string) => {
     await input.press('Enter');
   }
 
+  // Grafana 12 can occasionally discard fill() updates when the controlled input rerenders.
+  // Retry with real key events in that case; Grafana 13 normally commits through the option above.
+  if ((await input.inputValue()) !== value) {
+    await input.click();
+    await input.fill('');
+    await input.pressSequentially(value);
+    await input.press('Enter');
+  }
+
   await expect(input).toHaveValue(value);
 };
 


### PR DESCRIPTION
## Summary
- authenticate `/api/v1/plugin/install` by validating the existing Grafana service-account token against operator-configured `GRAFANA_API_URL`
- require the token's plugin-scoped `plugins:write` permission before installation can create or update an organization
- trust only operator-configured `GRAFANA_PUBLIC_URL` for the synchronized public authority; it defaults to `GRAFANA_API_URL`
- add regression coverage for missing configuration, invalid or under-scoped tokens, unavailable Grafana, untrusted payload URLs, and split internal/public URLs
- stabilize the rebased Grafana 12.4.8 time-input helper by retrying with key events when its controlled input rejects `fill()`

## Why no separate install secret
The install request already contains a Grafana service-account token. The engine validates it only against the configured internal Grafana and requires `plugins:write` for `plugins:id:grafana-oncall-app`. This proves the caller controls an authorized credential without another shared secret. Both internal and persisted public authorities are selected by operator configuration, never by the request alone.

## Configuration
Existing deployments need no change: `GRAFANA_PUBLIC_URL` defaults to `GRAFANA_API_URL`. Deployments whose engine uses an internal Grafana endpoint can set `GRAFANA_PUBLIC_URL` to Grafana's externally configured root URL.

## Testing
- focused install tests: 7 passed
- Ruff formatting/lint passed
- all Compose configurations render
- previous revision reached 18/18 green CI; fresh CI triggered for the final trusted-public-URL change