### PR TITLE
Upgrade broker and cache stack

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       rabbit_test:
-        image: rabbitmq:3.12.0
+        image: rabbitmq:4.3.5
         env:
           RABBITMQ_DEFAULT_USER: rabbitmq
           RABBITMQ_DEFAULT_PASS: rabbitmq
@@ -220,7 +220,7 @@ jobs:
       ONCALL_TESTING_RBAC_ENABLED: ${{ matrix.rbac_enabled }}
     services:
       rabbit_test:
-        image: rabbitmq:3.12.0
+        image: rabbitmq:4.3.5
         env:
           RABBITMQ_DEFAULT_USER: rabbitmq
           RABBITMQ_DEFAULT_PASS: rabbitmq
@@ -259,7 +259,7 @@ jobs:
       ONCALL_TESTING_RBAC_ENABLED: ${{ matrix.rbac_enabled }}
     services:
       rabbit_test:
-        image: rabbitmq:3.12.0
+        image: rabbitmq:4.3.5
         env:
           RABBITMQ_DEFAULT_USER: rabbitmq
           RABBITMQ_DEFAULT_PASS: rabbitmq
@@ -303,7 +303,7 @@ jobs:
       ONCALL_TESTING_RBAC_ENABLED: ${{ matrix.rbac_enabled }}
     services:
       redis_test:
-        image: redis:7.0.15
+        image: redis:8.2.9
         ports:
           - 6379:6379
         options: >-

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -172,7 +172,7 @@ services:
   redis:
     container_name: redis
     labels: *oncall-labels
-    image: redis:7.0.15
+    image: redis:8.2.9
     restart: always
     ports:
       - "6379:6379"
@@ -195,7 +195,7 @@ services:
   rabbitmq:
     container_name: rabbitmq
     labels: *oncall-labels
-    image: "rabbitmq:3.12.0-management"
+    image: "rabbitmq:4.3.5-management"
     restart: always
     environment:
       RABBITMQ_DEFAULT_USER: "rabbitmq"

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -88,7 +88,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7.0.15
+    image: redis:8.2.9
     restart: always
     expose:
       - 6379
@@ -99,7 +99,7 @@ services:
           cpus: "0.1"
 
   rabbitmq:
-    image: "rabbitmq:3.12.0-management"
+    image: "rabbitmq:4.3.5-management"
     restart: always
     hostname: rabbitmq
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         condition: service_healthy
 
   redis:
-    image: redis:7.0.15
+    image: redis:8.2.9
     restart: always
     expose:
       - 6379

--- a/engine/requirements.in
+++ b/engine/requirements.in
@@ -1,6 +1,6 @@
 babel==2.12.1
 beautifulsoup4==4.12.2
-celery[redis]==5.3.6
+celery[redis]==5.6.3
 cryptography==50.0.0
 django==5.2.17
 django-add-default-value==0.10.0
@@ -27,7 +27,7 @@ drf-spectacular==0.30.0
 emoji==2.4.0
 grpcio==1.76.0
 fcm-django==3.2.0
-hiredis==2.2.3
+hiredis==3.4.1
 humanize==4.10.0
 icalendar==5.0.10
 jinja2==3.1.6
@@ -49,7 +49,7 @@ pymdown-extensions==11.0.1
 PyMySQL==1.1.1
 python-telegram-bot==22.5
 recurring-ical-events==2.1.0
-redis==5.0.1
+redis==6.4.0
 regex==2024.7.24
 requests==2.34.2
 slack-export-viewer==1.1.4

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -31,7 +31,7 @@ botocore==1.43.70
     #   s3transfer
 cachecontrol==0.14.4
     # via firebase-admin
-celery==5.3.6
+celery==5.6.3
     # via -r requirements.in
 certifi==2026.7.22
     # via
@@ -205,7 +205,7 @@ h11==0.16.0
     # via httpcore
 h2==4.4.1
     # via httpx
-hiredis==2.2.3
+hiredis==3.4.1
     # via -r requirements.in
 hpack==4.2.0
     # via h2
@@ -395,11 +395,11 @@ pyyaml==6.0.3
     #   pymdown-extensions
 recurring-ical-events==2.1.0
     # via -r requirements.in
-redis==5.0.1
+redis==6.4.0
     # via
     #   -r requirements.in
-    #   celery
     #   django-redis
+    #   kombu
 referencing==0.37.0
     # via
     #   jsonschema
@@ -464,9 +464,9 @@ typing-extensions==4.16.0
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 tzdata==2026.3
-    # via
-    #   celery
-    #   kombu
+    # via kombu
+tzlocal==5.4.4
+    # via celery
 uritemplate==4.2.0
     # via
     #   drf-spectacular


### PR DESCRIPTION
## Summary
- upgrade RabbitMQ from 3.12.0 to 4.3.5
- upgrade Redis server from 7.0.15 to 8.2.9
- upgrade Celery to 5.6.3, redis-py to the newest Celery-compatible release (6.4.0), and hiredis to 3.4.1
- apply the service upgrades consistently to CI and development Compose files

## Validation
- 4,315 backend tests passed against Redis 8.2.9 (13 skipped)
- Redis and RabbitMQ client connection smokes passed
- `ty check`
- all pre-commit hooks
- Compose configuration validation

`redis-py` remains on 6.4.0 because Celery 5.6/Kombu constrains the Redis client to `<6.5`; this is compatible with the Redis 8.2 server.