### PR TITLE
Upgrade database compatibility matrix

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -66,7 +66,7 @@ jobs:
         ports:
           - 5672:5672
       mysql_test:
-        image: mysql:8.0.32
+        image: mysql:8.4.11
         env:
           MYSQL_DATABASE: oncall_local_dev
           MYSQL_ROOT_PASSWORD: local_dev_pwd
@@ -227,7 +227,7 @@ jobs:
         ports:
           - 5672:5672
       mysql_test:
-        image: mysql:8.0.32
+        image: mysql:8.4.11
         env:
           MYSQL_DATABASE: oncall_local_dev
           MYSQL_ROOT_PASSWORD: local_dev_pwd
@@ -266,7 +266,7 @@ jobs:
         ports:
           - 5672:5672
       postgresql_test:
-        image: postgres:14.4
+        image: postgres:18.6
         env:
           POSTGRES_DB: oncall_local_dev
           POSTGRES_PASSWORD: local_dev_pwd

--- a/dev/helm-local.yml
+++ b/dev/helm-local.yml
@@ -55,7 +55,7 @@ grafana:
   replicas: 1
   extraInitContainers:
     - name: create-db-if-not-exists
-      image: mysql:8.0.32
+      image: mysql:8.4.11
       command:
         # yamllint disable rule:line-length
         [

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -223,10 +223,10 @@ services:
   mysql:
     container_name: mysql
     labels: *oncall-labels
-    image: mysql:8.0.32
+    image: mysql:8.4.11
     command: >-
-      --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4
-      --collation-server=utf8mb4_unicode_ci --max_connections=1024
+      --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+      --max_connections=1024
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: empty
@@ -251,7 +251,7 @@ services:
   mysql_to_create_grafana_db:
     container_name: mysql_to_create_grafana_db
     labels: *oncall-labels
-    image: mysql:8.0.32
+    image: mysql:8.4.11
     command: >-
       bash -c "mysql -h mysql -uroot -pempty
       -e 'CREATE DATABASE IF NOT EXISTS grafana CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
@@ -264,7 +264,7 @@ services:
   postgres:
     container_name: postgres
     labels: *oncall-labels
-    image: postgres:14.4
+    image: postgres:18.6
     restart: always
     environment:
       POSTGRES_DB: oncall_local_dev
@@ -284,14 +284,14 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - postgresdata_dev:/var/lib/postgresql/data
+      - postgresdata_dev:/var/lib/postgresql
     profiles:
       - postgres
 
   postgres_to_create_grafana_db:
     container_name: postgres_to_create_grafana_db
     labels: *oncall-labels
-    image: postgres:14.4
+    image: postgres:18.6
     command: >-
       bash -c "PGPASSWORD=empty psql -U postgres
       -h postgres -tc \"SELECT 1 FROM pg_database WHERE datname = 'grafana'\" | grep -q 1 || PGPASSWORD=empty psql

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -226,6 +226,7 @@ services:
     image: mysql:8.4.11
     command: >-
       --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+      --mysql-native-password=ON
       --max_connections=1024
     restart: always
     environment:

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -68,6 +68,7 @@ services:
     image: mysql:8.4.11
     command: >-
       --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+      --mysql-native-password=ON
     restart: always
     expose:
       - 3306

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -65,9 +65,8 @@ services:
         condition: service_healthy
 
   mysql:
-    image: mysql:8.0.32
+    image: mysql:8.4.11
     command: >-
-      --default-authentication-plugin=mysql_native_password
       --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     restart: always
     expose:
@@ -120,7 +119,7 @@ services:
       retries: 3
 
   mysql_to_create_grafana_db:
-    image: mysql:8.0.32
+    image: mysql:8.4.11
     command: >-
       bash -c "mysql -h ${MYSQL_HOST:-mysql} -uroot -p${MYSQL_PASSWORD:?err}
       -e 'CREATE DATABASE IF NOT EXISTS grafana CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"


### PR DESCRIPTION
## Summary
- upgrade MySQL 8.0.32 to the current 8.4 LTS patch, 8.4.11
- upgrade PostgreSQL 14.4 to 18.6
- remove MySQL's deleted `default-authentication-plugin` server option
- use PostgreSQL 18's version-aware data volume layout in development Compose
- update CI, development Compose, and local Helm dependencies consistently

## Validation
- blank-slate migrations passed on MySQL 8.4.11
- 4,315 backend tests passed on MySQL 8.4.11 (13 skipped)
- blank-slate migrations passed on PostgreSQL 18.6
- 4,315 backend tests passed on PostgreSQL 18.6 (13 skipped)
- all pre-commit hooks
- Compose configuration validation

## Upgrade note
PostgreSQL major versions require dump/restore or `pg_upgrade`. Existing `postgresdata_dev` users should migrate their data or recreate the development volume before starting PostgreSQL 18.