### PR TITLE
Harden security, releases, and compatibility governance

### DIFF
--- a/.github/actions/install-frontend-dependencies/action.yml
+++ b/.github/actions/install-frontend-dependencies/action.yml
@@ -5,19 +5,23 @@ inputs:
     description: "Relative path to oncall directory"
     required: false
     default: "."
+  cache-dependencies:
+    description: "Whether to restore and save the pnpm dependency cache"
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
-    - name: Install pnpm
-      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      with:
-        version: 12.0.0
     - name: Determine grafana-plugin directory location
       id: grafana-plugin-directory
       shell: bash
       env:
         ONCALL_DIRECTORY: ${{ inputs.oncall-directory }}
       run: echo "grafana-plugin-directory=${{ env.ONCALL_DIRECTORY }}/grafana-plugin" >> $GITHUB_OUTPUT
+    - name: Install pnpm
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      with:
+        package_json_file: ${{ steps.grafana-plugin-directory.outputs.grafana-plugin-directory }}/package.json
     - name: Determine pnpm-lock.yaml location
       id: pnpm-lock-location
       shell: bash
@@ -26,8 +30,8 @@ runs:
       # yamllint enable rule:line-length
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
-        node-version: 24.20.0
-        cache: pnpm
+        node-version-file: ${{ inputs.oncall-directory }}/.nvmrc
+        cache: ${{ inputs.cache-dependencies == 'true' && 'pnpm' || '' }}
         cache-dependency-path: ${{ steps.pnpm-lock-location.outputs.pnpm-lock-location }}
     - name: Install frontend dependencies
       shell: bash

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,1 +1,88 @@
-{ "enabled": false }
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "group:monorepos",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "dependencyDashboard": true,
+  "labels": ["dependencies"],
+  "timezone": "Europe/London",
+  "schedule": ["before 6am on Monday"],
+  "minimumReleaseAge": "7 days",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "rangeStrategy": "pin",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the two explicitly supported Grafana lines",
+      "managerFilePatterns": ["/^\\.github/workflows/linting-and-tests\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s*\\n\\s*- (?<currentValue>\\S+)"
+      ],
+      "versioningTemplate": "docker"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Require explicit approval for major upgrades",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Group non-major frontend development dependencies",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "frontend development dependencies"
+    },
+    {
+      "description": "Group non-major Python dependencies",
+      "matchManagers": ["pip_requirements"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Python dependencies"
+    },
+    {
+      "description": "Group non-major Go dependencies",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Go dependencies"
+    },
+    {
+      "description": "Group service and build container updates",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "container dependencies"
+    },
+    {
+      "description": "Keep Grafana 12 updates within the tested minor line",
+      "matchDepNames": ["grafana/grafana"],
+      "matchCurrentVersion": "/^12\\.4\\./",
+      "allowedVersions": "<12.5"
+    },
+    {
+      "description": "Keep Grafana 13 updates within the tested minor line",
+      "matchDepNames": ["grafana/grafana"],
+      "matchCurrentVersion": "/^13\\.2\\./",
+      "allowedVersions": "<13.3"
+    },
+    {
+      "description": "Process vulnerability alerts immediately",
+      "matchCategories": ["security"],
+      "schedule": ["at any time"],
+      "minimumReleaseAge": null,
+      "dependencyDashboardApproval": false,
+      "prPriority": 10,
+      "labels": ["dependencies", "security"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  }
+}

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -355,7 +355,9 @@ jobs:
     strategy:
       matrix:
         grafana_version:
+          # renovate: datasource=docker depName=grafana/grafana
           - 12.4.8
+          # renovate: datasource=docker depName=grafana/grafana
           - 13.2.0
       fail-fast: false
     with:

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -109,6 +109,7 @@ jobs:
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           MERGE_BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
           RELEASE_TARGET: ${{ github.event.release.target_commitish }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           # Determine base ref from safe, pre-evaluated env variables
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
@@ -117,6 +118,8 @@ jobs:
             BASE_REF="$MERGE_BASE_REF"
           elif [[ "$EVENT_NAME" == "release" ]]; then
             BASE_REF="$RELEASE_TARGET"
+          elif [[ "$EVENT_NAME" == "schedule" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            BASE_REF="$DEFAULT_BRANCH"
           else
             echo "Unsupported event: $EVENT_NAME"
             exit 1
@@ -144,7 +147,7 @@ jobs:
         run: |
           # Use validated ref
           SAFE_REF="${{ steps.extract_base_ref.outputs.base_ref }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
 
           # Get the list of files changed in the PR using validated refs
           git diff --name-only "refs/remotes/origin/${SAFE_REF}...${HEAD_SHA}" > changed_files.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,53 @@
-name: Publish engine Docker image
+name: Publish release
 
 on:
   push:
     tags:
       - v*
 
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 env:
   IMAGE: ghcr.io/appwrite/grafana-oncall
 
 jobs:
+  verify:
+    name: Verify release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag and release commit
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be a semantic version prefixed with v: $RELEASE_TAG"
+            exit 1
+          fi
+
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+            echo "Release commit $RELEASE_SHA is not part of origin/main"
+            exit 1
+          fi
+
   build:
-    name: Build ${{ matrix.arch }}
+    name: Build engine (${{ matrix.arch }})
+    needs: verify
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: amd64
@@ -23,8 +59,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout project
+      - name: Check out project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set engine version number in settings file
         uses: ./.github/actions/set-engine-version-in-settings
@@ -36,61 +74,49 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Login to GHCR
+      - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push ${{ matrix.arch }} image
+      - name: Build and push staged image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: engine/
           platforms: linux/${{ matrix.arch }}
           target: prod
           push: true
+          provenance: mode=max
+          sbom: true
           tags: ${{ env.IMAGE }}:${{ github.ref_name }}-${{ matrix.arch }}
-
-  publish:
-    name: Publish multi-arch manifest
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Login to GHCR
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create and push manifest
-        run: |
-          docker buildx imagetools create \
-            --tag ${{ env.IMAGE }}:${{ github.ref_name }} \
-            --tag ${{ env.IMAGE }}:latest \
-            ${{ env.IMAGE }}:${{ github.ref_name }}-amd64 \
-            ${{ env.IMAGE }}:${{ github.ref_name }}-arm64
 
   plugin:
     name: Package Grafana plugin
+    needs: verify
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      attestations: write
+      contents: read
+      id-token: write
     steps:
-      - name: Checkout project
+      - name: Check out project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install frontend dependencies
         uses: ./.github/actions/install-frontend-dependencies
+        with:
+          cache-dependencies: "false"
 
       - name: Install Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: grafana-plugin/go.mod
           cache-dependency-path: grafana-plugin/go.sum
+          cache: false
 
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15.0
@@ -102,36 +128,166 @@ jobs:
         run: |
           set -euo pipefail
 
-          # a version without the leading "v" is what tells the plugin it is an OSS build, and it
-          # has to be stamped before either build: Rsbuild substitutes it into plugin.json and the
-          # backend bakes it into the binary
           version="${TAG#v}"
-          jq --arg v "$version" '.version=$v' package.json > package.tmp && mv package.tmp package.json
+          jq --arg v "$version" '.version=$v' package.json > package.tmp
+          mv package.tmp package.json
 
           pnpm build
           mage -v build:linux build:linuxARM64
 
-          # the plugin declares a backend, so a frontend-only archive would not load
           test -f dist/gpx_grafana_oncall_app_linux_amd64
           test -f dist/gpx_grafana_oncall_app_linux_arm64
 
-          # grafana expects the archive's directory to be named after the plugin id. The build is
-          # unsigned — we have no grafana.com access policy to sign under — so installs need the
-          # plugin allow-listed via GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS.
+          # Grafana expects the archive directory to use the plugin ID. The plugin is unsigned,
+          # so deployments must allow-list it with GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS.
           mv dist grafana-oncall-app
           zip -qr "grafana-oncall-app-${version}.zip" ./grafana-oncall-app
           sha256sum "grafana-oncall-app-${version}.zip" > "grafana-oncall-app-${version}.zip.sha256"
 
-      - name: Attach plugin to release
-        working-directory: grafana-plugin
+      - name: Generate plugin SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          path: grafana-plugin/grafana-oncall-app
+          format: spdx-json
+          output-file: grafana-plugin/plugin-sbom.spdx.json
+          upload-artifact: false
+
+      - name: Attest plugin provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: grafana-plugin/grafana-oncall-app-*.zip
+
+      - name: Attest plugin SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: grafana-plugin/grafana-oncall-app-*.zip
+          sbom-path: grafana-plugin/plugin-sbom.spdx.json
+
+      - name: Stage plugin release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: plugin-release-assets
+          path: |
+            grafana-plugin/grafana-oncall-app-*.zip
+            grafana-plugin/grafana-oncall-app-*.zip.sha256
+            grafana-plugin/plugin-sbom.spdx.json
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish atomic release
+    needs:
+      - build
+      - plugin
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      packages: write
+    steps:
+      - name: Download plugin release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: plugin-release-assets
+          path: release-assets
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create versioned multi-architecture image
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          version="${TAG#v}"
-          gh release view "$TAG" >/dev/null 2>&1 || gh release create "$TAG" --generate-notes --title "$TAG"
-          gh release upload "$TAG" \
-            "grafana-oncall-app-${version}.zip" \
-            "grafana-oncall-app-${version}.zip.sha256" \
-            --clobber
+          docker buildx imagetools create \
+            --tag "$IMAGE:$RELEASE_TAG" \
+            "$IMAGE:$RELEASE_TAG-amd64" \
+            "$IMAGE:$RELEASE_TAG-arm64"
+
+      - name: Resolve image digest
+        id: image
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          digest=$(
+            docker buildx imagetools inspect "$IMAGE:$RELEASE_TAG" \
+              --format '{{json .Manifest.Digest}}' | tr -d '"'
+          )
+          if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "Could not resolve the published image digest: $digest"
+            exit 1
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Generate engine SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          image: ${{ env.IMAGE }}:${{ github.ref_name }}-amd64
+          format: spdx-json
+          output-file: release-assets/engine-amd64-sbom.spdx.json
+          upload-artifact: false
+
+      - name: Generate ARM64 engine SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          image: ${{ env.IMAGE }}:${{ github.ref_name }}-arm64
+          format: spdx-json
+          output-file: release-assets/engine-arm64-sbom.spdx.json
+          upload-artifact: false
+
+      - name: Attest engine provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign engine image
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: cosign sign --yes "$IMAGE@$IMAGE_DIGEST"
+
+      - name: Create release checksums
+        working-directory: release-assets
+        run: sha256sum grafana-oncall-app-*.zip plugin-sbom.spdx.json engine-*-sbom.spdx.json > SHA256SUMS
+
+      - name: Create draft release and upload assets
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            is_draft=$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)
+            if [[ "$is_draft" != "true" ]]; then
+              echo "Release $RELEASE_TAG already exists and is not a draft"
+              exit 1
+            fi
+          else
+            gh release create "$RELEASE_TAG" --draft --generate-notes --title "$RELEASE_TAG"
+          fi
+
+          gh release upload "$RELEASE_TAG" release-assets/* --clobber
+
+      - name: Promote image to latest
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: docker buildx imagetools create --tag "$IMAGE:latest" "$IMAGE@$IMAGE_DIGEST"
+
+      - name: Publish GitHub release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -251,19 +251,47 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Install Crane
-        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
-        with:
-          version: v0.22.0
-
       - name: Sign engine image
         env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
         run: cosign sign --yes "$IMAGE@$IMAGE_DIGEST"
 
+      - name: Create release manifest
+        working-directory: release-assets
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          plugin_archive=$(find . -maxdepth 1 -name 'grafana-oncall-app-*.zip' -print -quit)
+          plugin_archive="${plugin_archive#./}"
+          plugin_digest=$(sha256sum "$plugin_archive" | cut -d ' ' -f 1)
+
+          jq -n \
+            --arg version "$RELEASE_TAG" \
+            --arg engine_image "$IMAGE" \
+            --arg engine_digest "$IMAGE_DIGEST" \
+            --arg plugin_archive "$plugin_archive" \
+            --arg plugin_digest "sha256:$plugin_digest" \
+            '{
+              schemaVersion: 1,
+              version: $version,
+              engine: {
+                image: $engine_image,
+                digest: $engine_digest,
+                reference: ($engine_image + "@" + $engine_digest)
+              },
+              plugin: {
+                archive: $plugin_archive,
+                digest: $plugin_digest
+              }
+            }' > release-manifest.json
+
       - name: Create release checksums
         working-directory: release-assets
-        run: sha256sum grafana-oncall-app-*.zip plugin-sbom.spdx.json engine-*-sbom.spdx.json > SHA256SUMS
+        run: >-
+          sha256sum grafana-oncall-app-*.zip plugin-sbom.spdx.json
+          engine-*-sbom.spdx.json release-manifest.json > SHA256SUMS
 
       - name: Create draft release and upload assets
         env:
@@ -285,43 +313,19 @@ jobs:
 
           gh release upload "$RELEASE_TAG" release-assets/* --clobber
 
-      - name: Commit matched release
+      - name: Publish matched release
         id: release
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --latest
+
+      - name: Create versioned image alias
+        env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          set -euo pipefail
-          committed=false
-
-          rollback() {
-            if [[ "$committed" == "true" ]]; then
-              return
-            fi
-
-            if ! crane digest "$IMAGE:$RELEASE_TAG" >/dev/null 2>&1; then
-              return
-            fi
-
-            deleted=false
-            for attempt in 1 2 3 4 5; do
-              if crane delete "$IMAGE:$RELEASE_TAG"; then
-                deleted=true
-                break
-              fi
-              sleep $((attempt * 2))
-            done
-            if [[ "$deleted" != "true" ]]; then
-              echo "Failed to remove incomplete image $IMAGE:$RELEASE_TAG"
-              return 1
-            fi
-          }
-          trap rollback EXIT
-
           docker buildx imagetools create \
             --tag "$IMAGE:$RELEASE_TAG" \
             "$IMAGE@$IMAGE_DIGEST"
-          gh release edit "$RELEASE_TAG" --draft=false --latest
-          committed=true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -295,26 +295,10 @@ jobs:
         run: |
           set -euo pipefail
           committed=false
-          previous_latest=$(crane digest "$IMAGE:latest" 2>/dev/null || true)
 
           rollback() {
             if [[ "$committed" == "true" ]]; then
               return
-            fi
-
-            if [[ -n "$previous_latest" ]]; then
-              restored=false
-              for attempt in 1 2 3 4 5; do
-                if docker buildx imagetools create --tag "$IMAGE:latest" "$IMAGE@$previous_latest"; then
-                  restored=true
-                  break
-                fi
-                sleep $((attempt * 2))
-              done
-              if [[ "$restored" != "true" ]]; then
-                echo "Failed to restore $IMAGE:latest to $previous_latest"
-                return 1
-              fi
             fi
 
             if ! crane digest "$IMAGE:$RELEASE_TAG" >/dev/null 2>&1; then
@@ -338,7 +322,6 @@ jobs:
 
           docker buildx imagetools create \
             --tag "$IMAGE:$RELEASE_TAG" \
-            --tag "$IMAGE:latest" \
             "$IMAGE@$IMAGE_DIGEST"
           gh release edit "$RELEASE_TAG" --draft=false --latest
           committed=true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -251,6 +251,11 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      - name: Install Crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+        with:
+          version: v0.22.0
+
       - name: Sign engine image
         env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
@@ -322,6 +327,18 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          published=false
+
+          remove_unpublished_alias() {
+            if [[ "$published" == "true" ]]; then
+              return
+            fi
+            if crane digest "$IMAGE:$RELEASE_TAG" >/dev/null 2>&1; then
+              crane delete "$IMAGE:$RELEASE_TAG"
+            fi
+          }
+          trap remove_unpublished_alias EXIT
+
           docker buildx imagetools create \
             --tag "$IMAGE:$RELEASE_TAG" \
             "$IMAGE@$IMAGE_DIGEST"
@@ -336,3 +353,4 @@ jobs:
           fi
 
           gh release edit "$RELEASE_TAG" --draft=false --latest
+          published=true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -313,19 +313,26 @@ jobs:
 
           gh release upload "$RELEASE_TAG" release-assets/* --clobber
 
-      - name: Publish matched release
+      - name: Commit matched release
         id: release
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: gh release edit "$RELEASE_TAG" --draft=false --latest
-
-      - name: Create versioned image alias
-        env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
           docker buildx imagetools create \
             --tag "$IMAGE:$RELEASE_TAG" \
             "$IMAGE@$IMAGE_DIGEST"
+
+          alias_digest=$(
+            docker buildx imagetools inspect "$IMAGE:$RELEASE_TAG" \
+              --format '{{json .Manifest.Digest}}' | tr -d '"'
+          )
+          if [[ "$alias_digest" != "$IMAGE_DIGEST" ]]; then
+            echo "Version alias points to $alias_digest instead of $IMAGE_DIGEST"
+            exit 1
+          fi
+
+          gh release edit "$RELEASE_TAG" --draft=false --latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -295,21 +295,50 @@ jobs:
         run: |
           set -euo pipefail
           committed=false
+          previous_latest=$(crane digest "$IMAGE:latest" 2>/dev/null || true)
 
           rollback() {
-            if [[ "$committed" != "true" ]]; then
-              crane delete "$IMAGE:$RELEASE_TAG" || true
+            if [[ "$committed" == "true" ]]; then
+              return
+            fi
+
+            if [[ -n "$previous_latest" ]]; then
+              restored=false
+              for attempt in 1 2 3 4 5; do
+                if docker buildx imagetools create --tag "$IMAGE:latest" "$IMAGE@$previous_latest"; then
+                  restored=true
+                  break
+                fi
+                sleep $((attempt * 2))
+              done
+              if [[ "$restored" != "true" ]]; then
+                echo "Failed to restore $IMAGE:latest to $previous_latest"
+                return 1
+              fi
+            fi
+
+            if ! crane digest "$IMAGE:$RELEASE_TAG" >/dev/null 2>&1; then
+              return
+            fi
+
+            deleted=false
+            for attempt in 1 2 3 4 5; do
+              if crane delete "$IMAGE:$RELEASE_TAG"; then
+                deleted=true
+                break
+              fi
+              sleep $((attempt * 2))
+            done
+            if [[ "$deleted" != "true" ]]; then
+              echo "Failed to remove incomplete image $IMAGE:$RELEASE_TAG"
+              return 1
             fi
           }
           trap rollback EXIT
 
           docker buildx imagetools create \
             --tag "$IMAGE:$RELEASE_TAG" \
+            --tag "$IMAGE:latest" \
             "$IMAGE@$IMAGE_DIGEST"
           gh release edit "$RELEASE_TAG" --draft=false --latest
           committed=true
-
-      - name: Promote release to latest
-        env:
-          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
-        run: docker buildx imagetools create --tag "$IMAGE:latest" "$IMAGE@$IMAGE_DIGEST"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -299,27 +299,7 @@ jobs:
           engine-*-sbom.spdx.json release-manifest.json > SHA256SUMS
 
       - name: Create draft release and upload assets
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            is_draft=$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)
-            if [[ "$is_draft" != "true" ]]; then
-              echo "Release $RELEASE_TAG already exists and is not a draft"
-              exit 1
-            fi
-          else
-            gh release create "$RELEASE_TAG" --draft --generate-notes --title "$RELEASE_TAG"
-          fi
-
-          gh release upload "$RELEASE_TAG" release-assets/* --clobber
-
-      - name: Commit matched release
-        id: release
+        id: draft
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -328,20 +308,64 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The published release and its manifest are authoritative. Publish
-          # them before exposing the optional human-readable container alias so
-          # cancellation cannot leave an engine alias without its plugin.
-          gh release edit "$RELEASE_TAG" --draft=false --latest
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            is_draft=$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)
+            if [[ "$is_draft" != "true" ]]; then
+              repair_dir=$(mktemp -d)
+              gh release download "$RELEASE_TAG" \
+                --pattern release-manifest.json \
+                --dir "$repair_dir"
+              published_digest=$(jq -r '.engine.digest' "$repair_dir/release-manifest.json")
+              if [[ ! "$published_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                echo "Published release has an invalid engine digest"
+                exit 1
+              fi
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+              echo "image_digest=$published_digest" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            gh release create "$RELEASE_TAG" --draft --generate-notes --title "$RELEASE_TAG"
+          fi
 
-          docker buildx imagetools create \
-            --tag "$IMAGE:$RELEASE_TAG" \
-            "$IMAGE@$IMAGE_DIGEST"
+          gh release upload "$RELEASE_TAG" release-assets/* --clobber
+          echo "already_published=false" >> "$GITHUB_OUTPUT"
+          echo "image_digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
 
-          alias_digest=$(
-            docker buildx imagetools inspect "$IMAGE:$RELEASE_TAG" \
-              --format '{{json .Manifest.Digest}}' | tr -d '"'
-          )
-          if [[ "$alias_digest" != "$IMAGE_DIGEST" ]]; then
-            echo "Version alias points to $alias_digest instead of $IMAGE_DIGEST"
+      - name: Commit matched release
+        id: release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALREADY_PUBLISHED: ${{ steps.draft.outputs.already_published }}
+          IMAGE_DIGEST: ${{ steps.draft.outputs.image_digest }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$ALREADY_PUBLISHED" != "true" ]]; then
+            # The manifest digest remains deployable even if alias creation
+            # needs repair. A rerun reads that published digest above.
+            gh release edit "$RELEASE_TAG" --draft=false --latest
+          fi
+
+          alias_verified=false
+          for attempt in 1 2 3 4 5; do
+            if docker buildx imagetools create \
+              --tag "$IMAGE:$RELEASE_TAG" \
+              "$IMAGE@$IMAGE_DIGEST"; then
+              if alias_digest=$(
+                docker buildx imagetools inspect "$IMAGE:$RELEASE_TAG" \
+                  --format '{{json .Manifest.Digest}}' | tr -d '"'
+              ) && [[ "$alias_digest" == "$IMAGE_DIGEST" ]]; then
+                alias_verified=true
+                break
+              fi
+            fi
+            sleep $((attempt * 2))
+          done
+
+          if [[ "$alias_verified" != "true" ]]; then
+            echo "Version alias does not point to $IMAGE_DIGEST"
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
           push: true
           provenance: mode=max
           sbom: true
-          tags: ${{ env.IMAGE }}:${{ github.ref_name }}-${{ matrix.arch }}
+          tags: ${{ env.IMAGE }}:staging-${{ github.run_id }}-${{ matrix.arch }}
 
   plugin:
     name: Package Grafana plugin
@@ -199,24 +199,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create versioned multi-architecture image
+      - name: Create staged multi-architecture image
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          STAGING_TAG: staging-${{ github.run_id }}
         run: |
           set -euo pipefail
           docker buildx imagetools create \
-            --tag "$IMAGE:$RELEASE_TAG" \
-            "$IMAGE:$RELEASE_TAG-amd64" \
-            "$IMAGE:$RELEASE_TAG-arm64"
+            --tag "$IMAGE:$STAGING_TAG" \
+            "$IMAGE:$STAGING_TAG-amd64" \
+            "$IMAGE:$STAGING_TAG-arm64"
 
       - name: Resolve image digest
         id: image
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          STAGING_TAG: staging-${{ github.run_id }}
         run: |
           set -euo pipefail
           digest=$(
-            docker buildx imagetools inspect "$IMAGE:$RELEASE_TAG" \
+            docker buildx imagetools inspect "$IMAGE:$STAGING_TAG" \
               --format '{{json .Manifest.Digest}}' | tr -d '"'
           )
           if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
@@ -228,7 +228,7 @@ jobs:
       - name: Generate engine SBOM
         uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
-          image: ${{ env.IMAGE }}:${{ github.ref_name }}-amd64
+          image: ${{ env.IMAGE }}:staging-${{ github.run_id }}-amd64
           format: spdx-json
           output-file: release-assets/engine-amd64-sbom.spdx.json
           upload-artifact: false
@@ -236,7 +236,7 @@ jobs:
       - name: Generate ARM64 engine SBOM
         uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
-          image: ${{ env.IMAGE }}:${{ github.ref_name }}-arm64
+          image: ${{ env.IMAGE }}:staging-${{ github.run_id }}-arm64
           format: spdx-json
           output-file: release-assets/engine-arm64-sbom.spdx.json
           upload-artifact: false
@@ -280,14 +280,28 @@ jobs:
 
           gh release upload "$RELEASE_TAG" release-assets/* --clobber
 
-      - name: Promote image to latest
-        env:
-          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
-        run: docker buildx imagetools create --tag "$IMAGE:latest" "$IMAGE@$IMAGE_DIGEST"
-
       - name: Publish GitHub release
+        id: release
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: gh release edit "$RELEASE_TAG" --draft=false --latest
+
+      - name: Promote signed engine image
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          docker buildx imagetools create \
+            --tag "$IMAGE:$RELEASE_TAG" \
+            --tag "$IMAGE:latest" \
+            "$IMAGE@$IMAGE_DIGEST"
+
+      - name: Restore draft release after failed image promotion
+        if: failure() && steps.release.outcome == 'success'
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: gh release edit "$RELEASE_TAG" --draft

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -342,8 +342,35 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          published="$ALREADY_PUBLISHED"
+          alias_created=false
+
+          remove_unpublished_alias() {
+            if [[ "$alias_created" != "true" || "$published" == "true" ]]; then
+              return
+            fi
+
+            removed=false
+            for attempt in 1 2 3 4 5; do
+              if crane delete "$IMAGE:$RELEASE_TAG" && \
+                ! crane digest "$IMAGE:$RELEASE_TAG" >/dev/null 2>&1; then
+                removed=true
+                break
+              fi
+              sleep $((attempt * 2))
+            done
+            if [[ "$removed" != "true" ]]; then
+              echo "Failed to remove incomplete alias $IMAGE:$RELEASE_TAG"
+              return 1
+            fi
+          }
+          trap 'exit 130' INT TERM
+          trap remove_unpublished_alias EXIT
 
           alias_verified=false
+          if [[ "$ALREADY_PUBLISHED" != "true" ]]; then
+            alias_created=true
+          fi
           for attempt in 1 2 3 4 5; do
             if docker buildx imagetools create \
               --tag "$IMAGE:$RELEASE_TAG" \
@@ -368,4 +395,5 @@ jobs:
           # A version alias created before this point is not a stable release.
           if [[ "$ALREADY_PUBLISHED" != "true" ]]; then
             gh release edit "$RELEASE_TAG" --draft=false --latest
+            published=true
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -251,6 +251,11 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      - name: Install Crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+        with:
+          version: v0.22.0
+
       - name: Sign engine image
         env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
@@ -280,28 +285,31 @@ jobs:
 
           gh release upload "$RELEASE_TAG" release-assets/* --clobber
 
-      - name: Publish GitHub release
+      - name: Commit matched release
         id: release
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: gh release edit "$RELEASE_TAG" --draft=false --latest
-
-      - name: Promote signed engine image
-        env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
+          set -euo pipefail
+          committed=false
+
+          rollback() {
+            if [[ "$committed" != "true" ]]; then
+              crane delete "$IMAGE:$RELEASE_TAG" || true
+            fi
+          }
+          trap rollback EXIT
+
           docker buildx imagetools create \
             --tag "$IMAGE:$RELEASE_TAG" \
-            --tag "$IMAGE:latest" \
             "$IMAGE@$IMAGE_DIGEST"
+          gh release edit "$RELEASE_TAG" --draft=false --latest
+          committed=true
 
-      - name: Restore draft release after failed image promotion
-        if: failure() && steps.release.outcome == 'success'
+      - name: Promote release to latest
         env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: gh release edit "$RELEASE_TAG" --draft
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: docker buildx imagetools create --tag "$IMAGE:latest" "$IMAGE@$IMAGE_DIGEST"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -327,32 +327,12 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          alias_created=false
-          published=false
 
-          remove_unpublished_alias() {
-            if [[ "$alias_created" != "true" || "$published" == "true" ]]; then
-              return
-            fi
+          # The published release and its manifest are authoritative. Publish
+          # them before exposing the optional human-readable container alias so
+          # cancellation cannot leave an engine alias without its plugin.
+          gh release edit "$RELEASE_TAG" --draft=false --latest
 
-            removed=false
-            for attempt in 1 2 3 4 5; do
-              if crane delete "$IMAGE:$RELEASE_TAG"; then
-                if ! crane digest "$IMAGE:$RELEASE_TAG" >/dev/null 2>&1; then
-                  removed=true
-                  break
-                fi
-              fi
-              sleep $((attempt * 2))
-            done
-            if [[ "$removed" != "true" ]]; then
-              echo "Failed to remove unpublished alias $IMAGE:$RELEASE_TAG"
-              return 1
-            fi
-          }
-          trap remove_unpublished_alias EXIT
-
-          alias_created=true
           docker buildx imagetools create \
             --tag "$IMAGE:$RELEASE_TAG" \
             "$IMAGE@$IMAGE_DIGEST"
@@ -365,6 +345,3 @@ jobs:
             echo "Version alias points to $alias_digest instead of $IMAGE_DIGEST"
             exit 1
           fi
-
-          gh release edit "$RELEASE_TAG" --draft=false --latest
-          published=true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -327,18 +327,32 @@ jobs:
           RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+          alias_created=false
           published=false
 
           remove_unpublished_alias() {
-            if [[ "$published" == "true" ]]; then
+            if [[ "$alias_created" != "true" || "$published" == "true" ]]; then
               return
             fi
-            if crane digest "$IMAGE:$RELEASE_TAG" >/dev/null 2>&1; then
-              crane delete "$IMAGE:$RELEASE_TAG"
+
+            removed=false
+            for attempt in 1 2 3 4 5; do
+              if crane delete "$IMAGE:$RELEASE_TAG"; then
+                if ! crane digest "$IMAGE:$RELEASE_TAG" >/dev/null 2>&1; then
+                  removed=true
+                  break
+                fi
+              fi
+              sleep $((attempt * 2))
+            done
+            if [[ "$removed" != "true" ]]; then
+              echo "Failed to remove unpublished alias $IMAGE:$RELEASE_TAG"
+              return 1
             fi
           }
           trap remove_unpublished_alias EXIT
 
+          alias_created=true
           docker buildx imagetools create \
             --tag "$IMAGE:$RELEASE_TAG" \
             "$IMAGE@$IMAGE_DIGEST"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -343,12 +343,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$ALREADY_PUBLISHED" != "true" ]]; then
-            # The manifest digest remains deployable even if alias creation
-            # needs repair. A rerun reads that published digest above.
-            gh release edit "$RELEASE_TAG" --draft=false --latest
-          fi
-
           alias_verified=false
           for attempt in 1 2 3 4 5; do
             if docker buildx imagetools create \
@@ -368,4 +362,10 @@ jobs:
           if [[ "$alias_verified" != "true" ]]; then
             echo "Version alias does not point to $IMAGE_DIGEST"
             exit 1
+          fi
+
+          # Publishing the matched GitHub release is the availability boundary.
+          # A version alias created before this point is not a stable release.
+          if [[ "$ALREADY_PUBLISHED" != "true" ]]; then
+            gh release edit "$RELEASE_TAG" --draft=false --latest
           fi

--- a/.github/workflows/scheduled-compatibility.yml
+++ b/.github/workflows/scheduled-compatibility.yml
@@ -1,0 +1,18 @@
+name: Scheduled compatibility
+
+on:
+  schedule:
+    - cron: "17 3 * * 3"
+  workflow_dispatch:
+
+concurrency:
+  group: scheduled-compatibility
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  compatibility:
+    name: Full compatibility suite
+    uses: ./.github/workflows/linting-and-tests.yml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -108,10 +108,26 @@ jobs:
       packages: read
       security-events: write
     steps:
-      - name: Scan latest engine image
+      - name: Resolve newest published release
+        id: release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag=$(gh api "repos/$GH_REPO/releases/latest" --jq .tag_name)
+          if gh release download "$tag" --pattern release-manifest.json; then
+            image=$(jq -r .engine.reference release-manifest.json)
+          else
+            # Releases made before the manifest was introduced use their immutable version tag.
+            image="ghcr.io/appwrite/grafana-oncall:$tag"
+          fi
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+      - name: Scan newest released engine image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ghcr.io/appwrite/grafana-oncall:latest
+          image-ref: ${{ steps.release.outputs.image }}
           format: sarif
           output: trivy-image-results.sarif
           severity: HIGH,CRITICAL

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,118 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "23 4 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - go
+          - javascript-typescript
+          - python
+    steps:
+      - name: Check out project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          category: /language:${{ matrix.language }}
+
+  filesystem-scan:
+    name: Filesystem vulnerability scan
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Check out project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Scan repository
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Upload scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-filesystem
+
+  released-image-scan:
+    name: Released image vulnerability scan
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Scan latest engine image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/appwrite/grafana-oncall:latest
+          format: sarif
+          output: trivy-image-results.sarif
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+
+      - name: Upload scan results
+        if: always()
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
+        with:
+          sarif_file: trivy-image-results.sarif
+          category: trivy-released-image

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,10 +40,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language:
-          - go
-          - javascript-typescript
-          - python
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
     steps:
       - name: Check out project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,8 +57,12 @@ jobs:
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: ${{ matrix.language }}
-          build-mode: none
+          build-mode: ${{ matrix.build-mode }}
           queries: security-extended
+
+      - name: Autobuild Go
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
 
       - name: Analyze
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -9,6 +9,8 @@ does not create a general support commitment for external deployments.
 - Engine and plugin versions must match.
 - A version becomes stable only when its GitHub release is published. A Git tag or container tag without a published
   GitHub release is an incomplete release and must not be deployed.
+- Each release contains `release-manifest.json`. Its engine digest and plugin checksum are the authoritative matched
+  artifacts. The versioned image tag is a convenience alias for that engine digest.
 - The release workflow publishes immutable version tags. It does not update the floating `latest` container tag.
 - Security and correctness fixes target the latest stable release. Backports are exceptional and are not guaranteed.
 - A superseded release stops receiving regular fixes when a new stable release is published.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -9,6 +9,7 @@ does not create a general support commitment for external deployments.
 - Engine and plugin versions must match.
 - A version becomes stable only when its GitHub release is published. A Git tag or container tag without a published
   GitHub release is an incomplete release and must not be deployed.
+- The release workflow publishes immutable version tags. It does not update the floating `latest` container tag.
 - Security and correctness fixes target the latest stable release. Backports are exceptional and are not guaranteed.
 - A superseded release stops receiving regular fixes when a new stable release is published.
 - Breaking configuration or migration changes require a major version. Deprecations should remain available for one

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,6 +7,8 @@ does not create a general support commitment for external deployments.
 
 - The latest stable release is the maintained release line.
 - Engine and plugin versions must match.
+- A version becomes stable only when its GitHub release is published. A Git tag or container tag without a published
+  GitHub release is an incomplete release and must not be deployed.
 - Security and correctness fixes target the latest stable release. Backports are exceptional and are not guaranteed.
 - A superseded release stops receiving regular fixes when a new stable release is published.
 - Breaking configuration or migration changes require a major version. Deprecations should remain available for one

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,46 @@
+# Compatibility and lifecycle policy
+
+Appwrite maintains this fork for its own deployments. This document defines what the automated test suite verifies. It
+does not create a general support commitment for external deployments.
+
+## Release support
+
+- The latest stable release is the maintained release line.
+- Engine and plugin versions must match.
+- Security and correctness fixes target the latest stable release. Backports are exceptional and are not guaranteed.
+- A superseded release stops receiving regular fixes when a new stable release is published.
+- Breaking configuration or migration changes require a major version. Deprecations should remain available for one
+  minor release when safe operation permits it.
+
+## Tested matrix
+
+The pull request and scheduled compatibility workflows test these versions:
+
+| Component | Tested versions | Policy |
+| --- | --- | --- |
+| Grafana | 12.4.8 and 13.2.0 | The latest tested release in each listed Grafana minor line |
+| Python | 3.13.11 | The engine build and backend test runtime |
+| Node.js | 24.20.0 | The plugin build and test runtime |
+| MySQL | 8.4.11 | Backend migrations and tests, with RabbitMQ |
+| PostgreSQL | 18.6 | Backend migrations and tests, with RabbitMQ |
+| SQLite | Python runtime version | Backend migrations and tests, with Redis |
+| Redis | 8.2.9 | Broker tests and development deployment |
+| RabbitMQ | 4.3.5 | Broker tests with MySQL and PostgreSQL |
+| Container architecture | linux/amd64 and linux/arm64 | Published engine images and plugin backend binaries |
+
+A version is supported only after it passes the repository test suite. A newer patch or minor version is not assumed to
+be compatible until the matrix is updated and passes. Versions outside the matrix can work, but the maintainers do not
+make a compatibility claim for them.
+
+## Validation cadence
+
+Every pull request runs linting, unit tests, database migrations, Helm tests, plugin builds, and Grafana end-to-end tests.
+The same compatibility suite runs every week even when the repository has no code changes. A scheduled failure is
+treated as a compatibility regression and must be resolved before the next release.
+
+## Upgrade policy
+
+Read the release notes before an upgrade. Back up the database before migrations run. Upgrade the engine and plugin in
+the same maintenance window. The automated suite validates migrations from a clean database, but it does not yet test
+an upgrade from persisted data. Use intermediate releases instead of skipping release lines unless the release notes
+state that the direct path is safe.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Published:
   frontend by version.
 - New releases publish signed container images, software bills of materials, and build provenance.
 - Each release includes an atomic manifest that matches the plugin archive to an immutable engine digest.
-- Container deployments must pin a release tag. The floating `latest` image is not updated.
+- Container deployments must pin a version tag only after its matching GitHub release is published. A container tag
+  without a published release is incomplete and unsupported. The floating `latest` image is not updated.
 
 ## What it does not offer
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Kept working:
 - Runs on Django 5.2 LTS. Upstream is on 4.2, whose extended support has ended.
 - The Insights page renders again. Its alert group variable produced invalid PromQL on Grafana 13.
 - Dependencies are patched, and end-to-end tests run against Grafana 12.4 and 13.2.
+- The tested runtimes and release lifecycle are defined in the
+  [compatibility policy](COMPATIBILITY.md).
 
 Published:
 
@@ -28,6 +30,7 @@ Published:
 - A plugin archive and its checksum on every
   [release](https://github.com/appwrite/grafana-oncall/releases), so a deployment can pin the
   frontend by version.
+- New releases publish signed container images, software bills of materials, and build provenance.
 
 ## What it does not offer
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Published:
   [release](https://github.com/appwrite/grafana-oncall/releases), so a deployment can pin the
   frontend by version.
 - New releases publish signed container images, software bills of materials, and build provenance.
+- Each release includes an atomic manifest that matches the plugin archive to an immutable engine digest.
 - Container deployments must pin a release tag. The floating `latest` image is not updated.
 
 ## What it does not offer

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Published:
   [release](https://github.com/appwrite/grafana-oncall/releases), so a deployment can pin the
   frontend by version.
 - New releases publish signed container images, software bills of materials, and build provenance.
+- Container deployments must pin a release tag. The floating `latest` image is not updated.
 
 ## What it does not offer
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are released for the latest stable version of this fork. Older versions do not receive regular fixes.
+Upgrade the engine and plugin together because mixed versions are not supported.
+
+See [COMPATIBILITY.md](COMPATIBILITY.md) for the tested runtime matrix and lifecycle policy.
+
+## Report a vulnerability
+
+Do not report a security vulnerability through a public issue, discussion, or pull request.
+
+Report it privately using either:
+
+1. [GitHub private vulnerability reporting](https://github.com/appwrite/grafana-oncall/security/advisories/new)
+2. Email [security@appwrite.io](mailto:security@appwrite.io)
+
+Include the affected version or commit, reproduction steps, impact, and any known mitigation. A minimal proof of concept
+is useful when it does not contain sensitive data.
+
+Appwrite aims to acknowledge a report within two business days and complete an initial severity assessment within seven
+business days. Remediation and disclosure timing depend on severity, exploitability, and release risk. Appwrite will
+coordinate disclosure with the reporter when the issue is confirmed.
+
+## Scope
+
+This policy covers the engine, Grafana plugin, container images, Helm chart, and release artifacts in this repository.
+Report vulnerabilities in another Appwrite project through that project's security policy or to
+[security@appwrite.io](mailto:security@appwrite.io).

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -8,7 +8,7 @@ x-oncall-build: &oncall-build-args
   target: ${ONCALL_IMAGE_TARGET:-dev}
   labels: *oncall-labels
   cache_from:
-    - ghcr.io/appwrite/grafana-oncall:latest
+    - ghcr.io/appwrite/grafana-oncall:v${ONCALL_VERSION:-1.24.7}
 
 x-oncall-volumes: &oncall-volumes
   - ./engine:/etc/app


### PR DESCRIPTION
## Summary

- add a security policy, private reporting guidance, CodeQL, dependency review, and scheduled Trivy scans
- make releases atomic across engine architectures and the plugin, then publish SBOMs, checksums, provenance attestations, and a keyless Cosign signature
- enable controlled Renovate updates with grouped non-major upgrades, approval-gated majors, security prioritization, and bounded Grafana patch updates
- publish the tested compatibility and lifecycle contract and rerun the full compatibility suite weekly
- source Node and pnpm versions from `.nvmrc` and `package.json` instead of duplicate CI pins

## Repository settings

Enabled alongside this PR because they are not stored in Git:

- GitHub private vulnerability reporting
- secret scanning
- secret scanning push protection

## Validation

- pre-commit hooks
- yamllint
- actionlint
- zizmor (no medium or high findings in the new workflows)
- Renovate config validator
- verified the multi-arch digest lookup against `v1.24.7`
