### PR TITLE
Publish Helm chart as signed OCI artifact

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -201,6 +201,10 @@ jobs:
           exit 1
       - name: Run tests
         run: helm unittest ./helm/oncall
+      - name: Lint and package chart
+        run: |
+          helm lint ./helm/oncall
+          helm package ./helm/oncall --destination "$RUNNER_TEMP"
 
   unit-test-backend-plugin:
     name: "Backend Tests: Plugin"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  CHART: ghcr.io/appwrite/helm-charts/oncall
   IMAGE: ghcr.io/appwrite/grafana-oncall
 
 jobs:
@@ -174,10 +175,53 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  chart:
+    name: Package Helm chart
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out project
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Package Helm chart
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          helm lint ./helm/oncall
+          helm package ./helm/oncall \
+            --version "$version" \
+            --app-version "$RELEASE_TAG" \
+            --destination chart-assets
+
+      - name: Attest Helm chart provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: chart-assets/oncall-*.tgz
+
+      - name: Stage Helm chart release asset
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: helm-chart-release-assets
+          path: chart-assets/oncall-*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
   publish:
     name: Publish atomic release
     needs:
       - build
+      - chart
       - plugin
     runs-on: ubuntu-latest
     permissions:
@@ -190,6 +234,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: plugin-release-assets
+          path: release-assets
+
+      - name: Download Helm chart release asset
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: helm-chart-release-assets
           path: release-assets
 
       - name: Log in to GHCR
@@ -271,6 +321,10 @@ jobs:
           plugin_archive=$(find . -maxdepth 1 -name 'grafana-oncall-app-*.zip' -print -quit)
           plugin_archive="${plugin_archive#./}"
           plugin_digest=$(sha256sum "$plugin_archive" | cut -d ' ' -f 1)
+          chart_archive=$(find . -maxdepth 1 -name 'oncall-*.tgz' -print -quit)
+          chart_archive="${chart_archive#./}"
+          chart_digest=$(sha256sum "$chart_archive" | cut -d ' ' -f 1)
+          chart_version="${RELEASE_TAG#v}"
 
           jq -n \
             --arg version "$RELEASE_TAG" \
@@ -278,6 +332,9 @@ jobs:
             --arg engine_digest "$IMAGE_DIGEST" \
             --arg plugin_archive "$plugin_archive" \
             --arg plugin_digest "sha256:$plugin_digest" \
+            --arg chart_archive "$chart_archive" \
+            --arg chart_digest "sha256:$chart_digest" \
+            --arg chart_reference "$CHART:$chart_version" \
             '{
               schemaVersion: 1,
               version: $version,
@@ -289,13 +346,18 @@ jobs:
               plugin: {
                 archive: $plugin_archive,
                 digest: $plugin_digest
+              },
+              chart: {
+                archive: $chart_archive,
+                digest: $chart_digest,
+                reference: $chart_reference
               }
             }' > release-manifest.json
 
       - name: Create release checksums
         working-directory: release-assets
         run: >-
-          sha256sum grafana-oncall-app-*.zip plugin-sbom.spdx.json
+          sha256sum grafana-oncall-app-*.zip oncall-*.tgz plugin-sbom.spdx.json
           engine-*-sbom.spdx.json release-manifest.json > SHA256SUMS
 
       - name: Create draft release and upload assets
@@ -397,3 +459,111 @@ jobs:
             gh release edit "$RELEASE_TAG" --draft=false --latest
             published=true
           fi
+
+  publish-chart:
+    name: Publish Helm chart as OCI artifact
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - name: Download Helm chart release asset
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: helm-chart-release-assets
+          path: chart-assets
+
+      - name: Restore authoritative chart from published release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          gh release download "$RELEASE_TAG" \
+            --pattern "oncall-$version.tgz" \
+            --dir chart-assets \
+            --clobber
+          gh release download "$RELEASE_TAG" \
+            --pattern release-manifest.json \
+            --dir chart-assets \
+            --clobber
+
+          expected_digest=$(jq -r '.chart.digest' chart-assets/release-manifest.json)
+          actual_digest="sha256:$(sha256sum "chart-assets/oncall-$version.tgz" | cut -d ' ' -f 1)"
+          if [[ "$actual_digest" != "$expected_digest" ]]; then
+            echo "Chart digest $actual_digest does not match release manifest $expected_digest"
+            exit 1
+          fi
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      - name: Install Crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+        with:
+          version: v0.22.0
+
+      - name: Log in OCI clients to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | helm registry login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+
+      - name: Push and verify Helm chart
+        id: chart
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          archive="chart-assets/oncall-$version.tgz"
+          test -f "$archive"
+
+          pushed=false
+          for attempt in 1 2 3; do
+            if push_output=$(helm push "$archive" oci://ghcr.io/appwrite/helm-charts); then
+              echo "$push_output"
+              pushed=true
+              break
+            fi
+            sleep $((attempt * 2))
+          done
+          if [[ "$pushed" != "true" ]]; then
+            echo "Could not push the Helm chart"
+            exit 1
+          fi
+
+          pushed_digest=$(sed -n 's/^Digest: //p' <<< "$push_output" | tail -1)
+          registry_digest=$(crane digest "$CHART:$version")
+          if [[ ! "$pushed_digest" =~ ^sha256:[0-9a-f]{64}$ || \
+            "$registry_digest" != "$pushed_digest" ]]; then
+            echo "Helm reported $pushed_digest but GHCR resolved $registry_digest"
+            exit 1
+          fi
+          echo "digest=$registry_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Attest Helm chart provenance in GHCR
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ${{ env.CHART }}
+          subject-digest: ${{ steps.chart.outputs.digest }}
+          push-to-registry: true
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign Helm chart
+        env:
+          CHART_DIGEST: ${{ steps.chart.outputs.digest }}
+        run: cosign sign --yes "$CHART@$CHART_DIGEST"

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,11 +6,11 @@ does not create a general support commitment for external deployments.
 ## Release support
 
 - The latest stable release is the maintained release line.
-- Engine and plugin versions must match.
+- Engine, plugin, and Helm chart versions must match.
 - A version becomes stable only when its GitHub release is published. A Git tag or container tag without a published
   GitHub release is an incomplete release and must not be deployed.
-- Each release contains `release-manifest.json`. Its engine digest and plugin checksum are the authoritative matched
-  artifacts. The versioned image tag is a convenience alias for that engine digest.
+- Each release contains `release-manifest.json`. Its engine digest, plugin checksum, and chart checksum are the
+  authoritative matched artifacts. Versioned registry tags are convenience aliases for those artifacts.
 - The release workflow publishes immutable version tags. It does not update the floating `latest` container tag.
 - Security and correctness fixes target the latest stable release. Backports are exceptional and are not guaranteed.
 - A superseded release stops receiving regular fixes when a new stable release is published.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Published:
 - A plugin archive and its checksum on every
   [release](https://github.com/appwrite/grafana-oncall/releases), so a deployment can pin the
   frontend by version.
+- A versioned Helm chart at `oci://ghcr.io/appwrite/helm-charts/oncall` and in each GitHub release.
 - New releases publish signed container images, software bills of materials, and build provenance.
-- Each release includes an atomic manifest that matches the plugin archive to an immutable engine digest.
+- Each release includes an atomic manifest that matches the engine, plugin archive, and Helm chart.
 - Container deployments must pin a version tag only after its matching GitHub release is published. A container tag
   without a published release is incomplete and unsupported. The floating `latest` image is not updated.
 
@@ -40,7 +41,6 @@ Published:
 - No support and no roadmap. We keep it working for our own use.
 - The plugin is unsigned, so Grafana needs
   `GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=grafana-oncall-app`.
-- The Helm chart is not published to a chart repository. Install it from a checkout.
 - The mobile app does not work. It relied on Grafana Cloud's push relay.
 
 ## Grafana OnCall

--- a/helm/oncall/README.md
+++ b/helm/oncall/README.md
@@ -23,26 +23,22 @@ Here are the instructions on how to set up your own [ingress](#set-up-external-a
 
 ## Install
 
-### Prepare the chart
-
-This chart is not published to a helm repository, so install it from a checkout:
-
-```bash
-git clone https://github.com/appwrite/grafana-oncall.git
-cd grafana-oncall
-```
-
 ### Installing the helm chart
 
 ```bash
-# Install the chart
+# Use a version from https://github.com/appwrite/grafana-oncall/releases.
+ONCALL_VERSION=VERSION
 helm install \
     --wait \
     --set base_url=example.com \
     --set grafana."grafana\.ini".server.domain=example.com \
+    --version "$ONCALL_VERSION" \
     release-oncall \
-    ./helm/oncall
+    oci://ghcr.io/appwrite/helm-charts/oncall
 ```
+
+The same chart archive is attached to the matching GitHub release. A checkout remains suitable for local chart
+development.
 
 Follow the `helm install` output to finish setting up Grafana OnCall backend and Grafana OnCall frontend plugin e.g.
 


### PR DESCRIPTION
## Summary

- package the Helm chart with the release version and attach the exact archive to the GitHub release
- record the chart archive, checksum, and OCI reference in `release-manifest.json`
- publish the authoritative release archive to `ghcr.io/appwrite/helm-charts/oncall`
- verify the OCI manifest digest, add GitHub provenance, and sign it with Cosign
- document OCI installation and enforce chart lint/package validation in pull requests

## Release safety

The GitHub release remains the availability boundary. OCI publication happens from the exact chart archive downloaded from that published release. The job validates its checksum against `release-manifest.json`, so reruns cannot substitute a newly packaged archive under the same version.

## Verification

- `pre-commit run --all-files`
- Actionlint on the release workflow
- `helm lint ./helm/oncall`
- `helm package ./helm/oncall --version 1.24.8 --app-version v1.24.8`
- `helm unittest ./helm/oncall` (111 tests)
